### PR TITLE
Fix missing Prettier template in setup skill installs

### DIFF
--- a/skills/slop-refinery-setup/references/templates/typescript/.prettierrc
+++ b/skills/slop-refinery-setup/references/templates/typescript/.prettierrc
@@ -1,5 +1,0 @@
-{
-    "tabWidth": 4,
-    "singleQuote": true,
-    "endOfLine": "lf"
-}

--- a/skills/slop-refinery-setup/references/templates/typescript/prettier.config.mjs
+++ b/skills/slop-refinery-setup/references/templates/typescript/prettier.config.mjs
@@ -1,0 +1,5 @@
+export default {
+    endOfLine: 'lf',
+    singleQuote: true,
+    tabWidth: 4,
+};

--- a/tests/skill-templates.test.ts
+++ b/tests/skill-templates.test.ts
@@ -1,0 +1,37 @@
+import { readdirSync } from 'node:fs';
+import path from 'node:path';
+import { expect, it } from 'vitest';
+
+import { repoPath } from './test-harness.ts';
+
+function collectHiddenEntries(
+    rootPath: string,
+    currentRelativePath = '',
+): string[] {
+    return readdirSync(path.join(rootPath, currentRelativePath), {
+        withFileTypes: true,
+    }).flatMap((entry) => {
+        const entryRelativePath = path.join(currentRelativePath, entry.name);
+        const hiddenEntries = entry.name.startsWith('.')
+            ? [entryRelativePath]
+            : [];
+
+        return entry.isDirectory()
+            ? [
+                  ...hiddenEntries,
+                  ...collectHiddenEntries(rootPath, entryRelativePath),
+              ]
+            : hiddenEntries;
+    });
+}
+
+it('avoids hidden template files that skills does not copy', () => {
+    const templateRootPath = repoPath(
+        'skills',
+        'slop-refinery-setup',
+        'references',
+        'templates',
+    );
+
+    expect(collectHiddenEntries(templateRootPath)).toStrictEqual([]);
+});


### PR DESCRIPTION
## Summary
- rename the setup skill's hidden `.prettierrc` template to `prettier.config.mjs`
- add a regression test that fails if hidden files are added under skill templates
- keep the existing Prettier settings unchanged while making the template compatible with `npx skills`

## Root cause
`npx skills add HOWMZofficial/slop-refinery --skill slop-refinery-setup` copies the setup skill but drops hidden files inside `references/templates/`. That meant `skills/slop-refinery-setup/references/templates/typescript/.prettierrc` never made it into the installed skill, even though the other template files did.

## Verification
- ran `npm run format`
- ran `npm run lint`
- ran `npm run typecheck`
- ran `npm test`
- reproduced `npx skills add /Users/lastmjs/.codex/worktrees/40d4/slop-refinery --skill slop-refinery-setup -y` and confirmed the installed template now includes `prettier.config.mjs`