### PR TITLE
Refactor slop-refinery into a multi-surface package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "slop-refinery",
-    "version": "0.0.0",
+    "version": "0.0.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "slop-refinery",
-            "version": "0.0.0",
+            "version": "0.0.4",
             "license": "MIT",
             "dependencies": {
                 "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "slop-refinery",
-    "version": "0.0.0",
+    "version": "0.0.4",
     "description": "Refines AI slop into clean code: correct, simple, maintainable",
     "type": "module",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/HOWMZofficial/slop-refinery.git"
+        "url": "git+https://github.com/HOWMZofficial/slop-refinery.git"
     },
     "exports": {
         ".": {
@@ -19,7 +19,7 @@
         }
     },
     "bin": {
-        "slop-refinery": "./dist/src/cli/bin.js"
+        "slop-refinery": "dist/src/cli/bin.js"
     },
     "files": [
         "dist/src",


### PR DESCRIPTION
## Summary
- rename the package to `slop-refinery` and split the source tree into `src/lib`, `src/cli`, and `src/eslint-plugin`
- expose the root library API, the `slop-refinery/eslint-plugin` subpath, and the `slop-refinery` CLI while updating docs, templates, and smoke tests
- move ruleset pull/push into the package-backed CLI and library, keep the `gh`-based flow, add CLI coverage, and fix publish metadata normalization for npm dry-run publishing

## Validation
- npm run format
- npm run lint
- npm run typecheck
- npm test
- npm publish --dry-run