### PR TITLE
Improve git cleanup remote deletion safety

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "slop-refinery",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "slop-refinery",
-            "version": "0.0.5",
+            "version": "0.0.6",
             "license": "MIT",
             "dependencies": {
                 "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     ],
     "scripts": {
         "format": "prettier --write . && eslint --fix --config eslint.format.config.ts .",
+        "git-cleanup": "tsx ./src/cli/bin.ts git-cleanup",
         "lint": "eslint .",
         "ruleset:pull": "tsx ./src/cli/bin.ts ruleset pull",
         "ruleset:push": "tsx ./src/cli/bin.ts ruleset push",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "slop-refinery",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "description": "Refines AI slop into clean code: correct, simple, maintainable",
     "type": "module",
     "license": "MIT",

--- a/src/cli/bin.ts
+++ b/src/cli/bin.ts
@@ -178,6 +178,12 @@ function getRulesetUsage(): string {
     ].join('\n');
 }
 
+function getGitCleanupApplyCommand(): string {
+    return process.env.npm_lifecycle_event === 'git-cleanup'
+        ? 'npm run git-cleanup -- --apply'
+        : 'slop-refinery git-cleanup --apply';
+}
+
 function parseRepoSlug(repoSlug: string): {
     owner: string;
     repo: string;
@@ -284,7 +290,10 @@ async function run(): Promise<void> {
             return;
         }
 
-        const options = parseGitCleanupArgs(resourceArgs);
+        const options = {
+            ...parseGitCleanupArgs(resourceArgs),
+            applyCommand: getGitCleanupApplyCommand(),
+        };
         const report = buildGitCleanupReport(options);
 
         console.log(renderGitCleanupOutput(report, options.json));

--- a/src/lib/git-cleanup.ts
+++ b/src/lib/git-cleanup.ts
@@ -425,6 +425,34 @@ type RemoteDeleteResult = {
     skippedReason: null | string;
 };
 
+type RecordedRemoteArchive = {
+    archivedSha: string;
+    backupRef: string;
+    backupReflogPrefix: string;
+    backupRepoPath: string;
+};
+
+type HostedRemoteDeleteBaseValidation =
+    | {
+          base: BaseRef;
+          status: 'ready';
+      }
+    | {
+          result: RemoteDeleteResult;
+          status: 'blocked';
+      };
+
+type HostedRemoteDeleteValidation =
+    | {
+          liveBranchProbe: Extract<LiveOriginBranchProbe, { kind: 'present' }>;
+          liveSha: string;
+          status: 'ready';
+      }
+    | {
+          result: RemoteDeleteResult;
+          status: 'blocked';
+      };
+
 type WorktreeArchiveSummary = {
     errors: string[];
     removedWorktrees: string[];
@@ -1172,8 +1200,9 @@ export function getGitCleanupUsage(): string {
         '',
         'Safety model:',
         '  origin must exist and its live default branch is the only canonical base.',
-        '  Automatic cleanup only removes active branch names whose local and origin history are already preserved on that base.',
-        '  Safe branches are archived into tool-managed refs before their active branch names are removed, so branch reflogs stay preserved.',
+        '  Automatic cleanup only removes branch names whose current local and origin tips are already preserved on that base.',
+        '  Local branches are archived into tool-managed refs before their active branch names are removed, so branch reflogs stay preserved.',
+        '  Hosted origin branches are deleted with a force-with-lease guard after their live SHA is revalidated.',
         '  Successful --apply runs prune redundant tool-managed archive refs unless --keep-archives is set.',
         '  Archive pruning only removes refs whose tip and reflog history are already preserved on the canonical base.',
         '  Linked worktrees always require manual review.',
@@ -1398,32 +1427,11 @@ function reconcileBranchesWithFinalProof(
     branches: BranchBuckets,
     finalDetachedWorktreeReports: FinalDetachedWorktreeReports,
 ): BranchBuckets {
-    const finalProofIssue =
-        finalDetachedWorktreeReports.baseIssue ??
-        finalDetachedWorktreeReports.repositoryIssue;
+    const finalProofIssue = finalDetachedWorktreeReports.baseIssue;
 
     return finalProofIssue === null
-        ? reconcileBranchesWithFinalDetachedWorktrees(
-              branches,
-              finalDetachedWorktreeReports.detachedWorktrees,
-          )
-        : failClosedSafeDeleteBranches(branches, finalProofIssue);
-}
-
-function reconcileBranchesWithFinalDetachedWorktrees(
-    branches: BranchBuckets,
-    detachedWorktrees: readonly DetachedWorktreeReport[],
-): BranchBuckets {
-    const blockingDetachedWorktrees = detachedWorktrees.filter(
-        (worktree) => !worktree.state.safeToRemoveManually,
-    );
-
-    return blockingDetachedWorktrees.length === 0
         ? branches
-        : failClosedSafeDeleteBranches(
-              branches,
-              `detached worktree state required manual review during the final report proof recheck (${blockingDetachedWorktrees.length} blocking detached worktree(s)).`,
-          );
+        : failClosedSafeDeleteBranches(branches, finalProofIssue);
 }
 
 function readFinalDetachedWorktreeReports(
@@ -2582,7 +2590,7 @@ function parseRemoteHeadSha(remoteHeadOutput: string): null | string {
 }
 
 function readOriginUrl(repoRoot: string): string {
-    return readGit(repoRoot, ['remote', 'get-url', 'origin']);
+    return readGit(repoRoot, ['config', '--get', 'remote.origin.url']);
 }
 
 function readReachableHiddenRefAnalysis(
@@ -3661,7 +3669,6 @@ function protectedBaseBranchNeedsReview(report: BranchReport): boolean {
 
     return (
         protectedBranchStateNeedsReview(state) ||
-        repositoryStateNeedsReview(state) ||
         protectedBaseRemoteStateNeedsReview(report.remoteBranch)
     );
 }
@@ -3678,19 +3685,6 @@ function protectedBranchStateNeedsReview(state: BranchState): boolean {
         !state.branchReflogAvailable ||
         state.branchReflogUniqueCommitCount > 0 ||
         state.hasBlockingDetachedWorktree
-    );
-}
-
-function repositoryStateNeedsReview(state: BranchState): boolean {
-    return (
-        state.repositoryLinkedWorktreeCount > 0 ||
-        state.repositoryWorktreeDirtyCount > 0 ||
-        !state.repositoryHiddenRefsAvailable ||
-        state.repositoryHiddenRefCount > 0 ||
-        !state.repositoryReflogAvailable ||
-        state.repositoryReflogUniqueCommitCount > 0 ||
-        !state.repositoryUnreachableCommitsAvailable ||
-        state.repositoryUnreachableCommitCount > 0
     );
 }
 
@@ -4064,19 +4058,14 @@ function assessBranchWithoutOriginUpstream(
     const liveBranchProbe = readLiveOriginBranchProbe(repoRoot, branch);
     const liveSha =
         liveBranchProbe.kind === 'present' ? liveBranchProbe.sha : null;
-
-    if (localTrackingSha !== null || liveBranchProbe.kind !== 'absent') {
-        return {
-            branch,
-            liveSha,
-            localTrackingProofFingerprint: null,
-            localTrackingSha,
-            remote: 'origin',
-            remoteSafetyProofFingerprint: null,
-            shortName,
-            status: 'identity_unverified',
-        };
-    }
+    const status = readOriginRemoteBranchStatus(
+        repoRoot,
+        base,
+        branch,
+        shortName,
+        liveBranchProbe,
+        localTrackingSha,
+    );
 
     return {
         branch,
@@ -4086,7 +4075,7 @@ function assessBranchWithoutOriginUpstream(
         remote: 'origin',
         remoteSafetyProofFingerprint: null,
         shortName,
-        status: 'history_unverified',
+        status,
     };
 }
 
@@ -4245,20 +4234,13 @@ function readOriginRemoteBranchStatus(
     }
 
     if (liveBranchProbe.kind === 'absent') {
-        if (localTrackingSha !== null) {
-            const trackingStatus = readLocalTrackingRefStatus(
-                repoRoot,
-                base,
-                trackingShortName,
-                localTrackingSha,
-            );
-
-            if (trackingStatus !== 'safe') {
-                return trackingStatus;
-            }
-        }
-
-        return readAbsentRemoteBranchStatus(repoRoot, base, branch);
+        return readAbsentRemoteBranchStatus(
+            repoRoot,
+            base,
+            trackingShortName,
+            branch,
+            localTrackingSha,
+        );
     }
 
     return readPresentOriginRemoteBranchStatus(
@@ -4333,6 +4315,10 @@ function readPresentOriginRemoteBranchStatus(
         return liveTipStatus;
     }
 
+    if (!originGitDirectoryIsLocallyInspectable(repoRoot, base)) {
+        return 'safe';
+    }
+
     const trackingStatus = readLocalTrackingRefStatus(
         repoRoot,
         base,
@@ -4392,6 +4378,13 @@ function readPresentOriginLiveTipStatus(
     ])
         ? 'safe'
         : 'live_tip_not_on_base';
+}
+
+function originGitDirectoryIsLocallyInspectable(
+    repoRoot: string,
+    base: BaseRef,
+): boolean {
+    return resolveLocalGitRemotePath(repoRoot, base.remoteUrl) !== null;
 }
 
 function readLocalTrackingRefStatus(
@@ -4560,11 +4553,36 @@ function readOriginCheckedOutWorktreeStatus(
 function readAbsentRemoteBranchStatus(
     repoRoot: string,
     base: BaseRef,
+    trackingShortName: string,
     branch: string,
+    localTrackingSha: null | string,
 ): Extract<
     RemoteBranchStatus,
-    'absent' | 'history_not_on_base' | 'history_unverified'
+    | 'absent'
+    | 'history_not_on_base'
+    | 'history_unverified'
+    | 'tracking_ref_not_on_base'
 > {
+    if (
+        localTrackingSha !== null &&
+        !gitSucceeded(repoRoot, [
+            'merge-base',
+            '--is-ancestor',
+            localTrackingSha,
+            base.liveSha,
+        ])
+    ) {
+        return 'tracking_ref_not_on_base';
+    }
+
+    if (!originGitDirectoryIsLocallyInspectable(repoRoot, base)) {
+        return 'absent';
+    }
+
+    if (readTrackedRemoteSha(repoRoot, trackingShortName) === null) {
+        return 'absent';
+    }
+
     const inspection = readRemoteHistoryInspection(repoRoot, base);
 
     if (inspection.status !== 'ready') {
@@ -4983,30 +5001,18 @@ function buildBranchState(
     const safeToDelete = isBranchSafeToDelete(
         branch,
         branchReflogAnalysis,
-        hasBlockingDetachedWorktree,
-        hiddenRefAnalysis,
         linkedWorktreeFlags,
         mergedByHistory,
         linkedWorktrees.length,
-        repositoryLinkedWorktreePaths.length,
-        repositoryDirtyWorktrees.length,
         remoteBranch,
-        repositoryReflogAnalysis,
-        unreachableCommitAnalysis,
     );
     const safetyProofFingerprint = buildBranchSafetyProofFingerprint(
         branch,
         branchReflogAnalysis,
-        hasBlockingDetachedWorktree,
-        hiddenRefAnalysis,
         linkedWorktreeFlags,
         mergedByHistory,
         linkedWorktrees.length,
-        repositoryLinkedWorktreePaths.length,
-        repositoryDirtyWorktrees.length,
         remoteBranch,
-        repositoryReflogAnalysis,
-        unreachableCommitAnalysis,
     );
 
     return {
@@ -5048,23 +5054,12 @@ function buildBranchState(
 function buildBranchSafetyProofFingerprint(
     branch: string,
     branchReflogAnalysis: ReflogAnalysis,
-    hasBlockingDetachedWorktree: boolean,
-    hiddenRefAnalysis: HiddenRefAnalysis,
     linkedWorktreeFlags: ReturnType<typeof readLinkedWorktreeFlags>,
     mergedByHistory: boolean,
     linkedWorktreeCount: number,
-    repositoryLinkedWorktreeCount: number,
-    repositoryDirtyWorktreeCount: number,
     remoteBranch: null | RemoteBranchAssessment,
-    repositoryReflogAnalysis: ReflogAnalysis,
-    unreachableCommitAnalysis: RepositoryUnreachableCommitAnalysis,
 ): null | string {
-    if (
-        branchReflogAnalysis.fingerprint === null ||
-        hiddenRefAnalysis.fingerprint === null ||
-        repositoryReflogAnalysis.fingerprint === null ||
-        unreachableCommitAnalysis.fingerprint === null
-    ) {
+    if (branchReflogAnalysis.fingerprint === null) {
         return null;
     }
 
@@ -5072,17 +5067,10 @@ function buildBranchSafetyProofFingerprint(
         JSON.stringify({
             branch,
             branchReflogFingerprint: branchReflogAnalysis.fingerprint,
-            hasBlockingDetachedWorktree,
-            hiddenRefFingerprint: hiddenRefAnalysis.fingerprint,
             linkedWorktreeCount,
             linkedWorktreeFlags,
             mergedByHistory,
             remoteBranch,
-            repositoryDirtyWorktreeCount,
-            repositoryLinkedWorktreeCount,
-            repositoryReflogFingerprint: repositoryReflogAnalysis.fingerprint,
-            repositoryUnreachableFingerprint:
-                unreachableCommitAnalysis.fingerprint,
         }),
     );
 }
@@ -5170,37 +5158,16 @@ function readWorktreesSafely(repoPath: string): null | WorktreeInfo[] {
 function isBranchSafeToDelete(
     branch: string,
     branchReflogAnalysis: ReflogAnalysis,
-    hasBlockingDetachedWorktree: boolean,
-    hiddenRefAnalysis: HiddenRefAnalysis,
     linkedWorktreeFlags: ReturnType<typeof readLinkedWorktreeFlags>,
     mergedByHistory: boolean,
     linkedWorktreeCount: number,
-    repositoryLinkedWorktreeCount: number,
-    repositoryDirtyWorktreeCount: number,
     remoteBranch: null | RemoteBranchAssessment,
-    repositoryReflogAnalysis: ReflogAnalysis,
-    unreachableCommitAnalysis: RepositoryUnreachableCommitAnalysis,
 ): boolean {
     return (
         mergedByHistory &&
         branchHasNoUniqueReflogCommits(branchReflogAnalysis) &&
-        !hasBlockingDetachedWorktree &&
-        repositoryLinkedWorktreeCount === 0 &&
-        repositoryDirtyWorktreeCount === 0 &&
-        repositoryHasNoReachableHiddenRefs(hiddenRefAnalysis) &&
-        repositoryHasNoUniqueReflogCommits(repositoryReflogAnalysis) &&
-        repositoryHasNoUnreachableCommits(unreachableCommitAnalysis) &&
         isRemoteBranchSafeToDelete(branch, remoteBranch) &&
         hasNoBlockingLinkedWorktrees(linkedWorktreeCount, linkedWorktreeFlags)
-    );
-}
-
-function repositoryHasNoUniqueReflogCommits(
-    repositoryReflogAnalysis: ReflogAnalysis,
-): boolean {
-    return (
-        repositoryReflogAnalysis.available &&
-        repositoryReflogAnalysis.uniqueCommitCount === 0
     );
 }
 
@@ -5211,21 +5178,6 @@ function branchHasNoUniqueReflogCommits(
         branchReflogAnalysis.available &&
         branchReflogAnalysis.uniqueCommitCount === 0
     );
-}
-
-function repositoryHasNoUnreachableCommits(
-    unreachableCommitAnalysis: RepositoryUnreachableCommitAnalysis,
-): boolean {
-    return (
-        unreachableCommitAnalysis.available &&
-        unreachableCommitAnalysis.commitCount === 0
-    );
-}
-
-function repositoryHasNoReachableHiddenRefs(
-    hiddenRefAnalysis: HiddenRefAnalysis,
-): boolean {
-    return hiddenRefAnalysis.available && hiddenRefAnalysis.refs.length === 0;
 }
 
 function hasNoBlockingLinkedWorktrees(
@@ -5258,11 +5210,7 @@ function isAbsentRemoteBranchSafe(
     branch: string,
     remoteBranch: RemoteBranchAssessment,
 ): boolean {
-    return (
-        remoteBranch.remote === 'origin' &&
-        remoteBranch.branch === branch &&
-        remoteBranch.remoteSafetyProofFingerprint !== null
-    );
+    return remoteBranch.remote === 'origin' && remoteBranch.branch === branch;
 }
 
 function isLiveRemoteBranchSafe(
@@ -5274,8 +5222,6 @@ function isLiveRemoteBranchSafe(
         remoteBranch.remote === 'origin' &&
         remoteBranch.branch === branch &&
         remoteBranch.liveSha !== null &&
-        remoteBranch.localTrackingProofFingerprint !== null &&
-        remoteBranch.remoteSafetyProofFingerprint !== null &&
         remoteBranch.localTrackingSha === remoteBranch.liveSha
     );
 }
@@ -5422,12 +5368,6 @@ function isKeptOnlyByProofGaps(state: BranchState): boolean {
         state.branchTipOnBase &&
         state.branchReflogAvailable &&
         state.branchReflogUniqueCommitCount === 0 &&
-        state.repositoryHiddenRefsAvailable &&
-        state.repositoryHiddenRefCount === 0 &&
-        state.repositoryReflogAvailable &&
-        state.repositoryReflogUniqueCommitCount === 0 &&
-        state.repositoryUnreachableCommitsAvailable &&
-        state.repositoryUnreachableCommitCount === 0 &&
         !state.safeToDelete
     );
 }
@@ -5460,15 +5400,6 @@ function collectBranchReasonCodes(
         ...(state.hasBlockingDetachedWorktree
             ? (['detached_worktree_requires_manual_review'] as const)
             : []),
-        ...(state.repositoryWorktreeDirtyCount > 0
-            ? (['repository_worktree_dirty'] as const)
-            : []),
-        ...(state.repositoryLinkedWorktreeCount > 0
-            ? (['repository_linked_worktrees_present'] as const)
-            : []),
-        ...readRepositoryHiddenRefReasonCodes(state),
-        ...readRepositoryReflogReasonCodes(state),
-        ...readRepositoryUnreachableCommitReasonCodes(state),
         ...readOriginBranchReasonCodes(
             branch,
             remoteBranch,
@@ -5485,48 +5416,6 @@ function readBranchReflogReasonCodes(state: BranchState): BranchReasonCode[] {
             : (['branch_reflog_unavailable'] as const)),
         ...(state.branchReflogUniqueCommitCount > 0
             ? (['branch_reflog_has_unique_commits'] as const)
-            : []),
-    ];
-}
-
-function readRepositoryUnreachableCommitReasonCodes(
-    state: BranchState,
-): BranchReasonCode[] {
-    return [
-        ...(!state.repositoryUnreachableCommitsAvailable
-            ? (['repository_unreachable_commits_unavailable'] as const)
-            : []),
-        ...(state.repositoryUnreachableCommitCount > 0
-            ? (['repository_unreachable_commits_present'] as const)
-            : []),
-        ...(state.repositoryWorktreeDirtyCount > 0
-            ? (['repository_worktree_dirty'] as const)
-            : []),
-    ];
-}
-
-function readRepositoryReflogReasonCodes(
-    state: BranchState,
-): BranchReasonCode[] {
-    return [
-        ...(!state.repositoryReflogAvailable
-            ? (['repository_reflog_unavailable'] as const)
-            : []),
-        ...(state.repositoryReflogUniqueCommitCount > 0
-            ? (['repository_reflog_has_unique_commits'] as const)
-            : []),
-    ];
-}
-
-function readRepositoryHiddenRefReasonCodes(
-    state: BranchState,
-): BranchReasonCode[] {
-    return [
-        ...(!state.repositoryHiddenRefsAvailable
-            ? (['repository_hidden_refs_unavailable'] as const)
-            : []),
-        ...(state.repositoryHiddenRefCount > 0
-            ? (['repository_hidden_refs_present'] as const)
             : []),
     ];
 }
@@ -5612,11 +5501,6 @@ function buildBranchReasonDetails(
         ...readBranchTipReasonDetails(baseShort, state),
         ...buildBranchReflogReasonDetails(baseShort, state),
         ...buildDetachedWorktreeBlockingReasonDetails(detachedWorktrees),
-        ...buildRepositoryWorktreeReasonDetails(state),
-        ...buildRepositoryLinkedWorktreeReasonDetails(state),
-        ...buildRepositoryHiddenRefReasonDetails(state),
-        ...buildRepositoryReflogReasonDetails(baseShort, state),
-        ...buildRepositoryUnreachableCommitReasonDetails(state),
         ...buildRemoteReasonDetails(
             branch,
             baseShort,
@@ -5687,105 +5571,6 @@ function buildBranchReflogReasonDetails(
     ];
 }
 
-function buildRepositoryWorktreeReasonDetails(state: BranchState): string[] {
-    if (state.repositoryWorktreeDirtyCount === 0) {
-        return [];
-    }
-
-    return [
-        `the repository has ${state.repositoryWorktreeDirtyCount} dirty, missing, or prunable worktree(s), so automatic cleanup fails closed.`,
-        ...state.repositoryWorktreeDirtyPaths.map(
-            (worktreePath) =>
-                `worktree ${worktreePath} has local state that requires manual review.`,
-        ),
-    ];
-}
-
-function buildRepositoryLinkedWorktreeReasonDetails(
-    state: BranchState,
-): string[] {
-    if (state.repositoryLinkedWorktreeCount === 0) {
-        return [];
-    }
-
-    const visiblePaths = state.repositoryLinkedWorktreePaths
-        .slice(0, 5)
-        .join(', ');
-    const suffix =
-        state.repositoryLinkedWorktreeCount > 5
-            ? ` and ${state.repositoryLinkedWorktreeCount - 5} more`
-            : '';
-
-    return [
-        `the repository has ${state.repositoryLinkedWorktreeCount} linked worktree(s), so automatic branch cleanup fails closed: ${visiblePaths}${suffix}.`,
-    ];
-}
-
-function buildRepositoryUnreachableCommitReasonDetails(
-    state: BranchState,
-): string[] {
-    if (!state.repositoryUnreachableCommitsAvailable) {
-        return [
-            'the repository-wide unreachable-commit scan could not complete, so expired reflog-only local history could not be ruled out automatically.',
-        ];
-    }
-
-    if (state.repositoryUnreachableCommitCount > 0) {
-        return [
-            `the repository still contains ${state.repositoryUnreachableCommitCount} unreachable object(s), so automatic cleanup fails closed until they are reviewed or pruned.`,
-        ];
-    }
-
-    return [
-        'the repository does not contain unreachable objects outside the current ref graph.',
-    ];
-}
-
-function buildRepositoryReflogReasonDetails(
-    baseShort: string,
-    state: BranchState,
-): string[] {
-    if (!state.repositoryReflogAvailable) {
-        return [
-            'the repository-wide reflog scan could not complete, so retained reflog-only history outside the canonical base could not be ruled out automatically.',
-        ];
-    }
-
-    if (state.repositoryReflogUniqueCommitCount > 0) {
-        return [
-            `the repository-wide reflog graph still references ${state.repositoryReflogUniqueCommitCount} commit(s) that are not reachable from ${baseShort}.`,
-        ];
-    }
-
-    return [
-        `the repository-wide reflog graph does not reference any commits that are still outside ${baseShort}.`,
-    ];
-}
-
-function buildRepositoryHiddenRefReasonDetails(state: BranchState): string[] {
-    if (!state.repositoryHiddenRefsAvailable) {
-        return [
-            'the repository-wide ref scan could not complete, so reachable refs outside the canonical base could not be ruled out automatically.',
-        ];
-    }
-
-    if (state.repositoryHiddenRefCount > 0) {
-        const visibleRefs = state.repositoryHiddenRefs.slice(0, 5).join(', ');
-        const suffix =
-            state.repositoryHiddenRefCount > 5
-                ? ` and ${state.repositoryHiddenRefCount - 5} more`
-                : '';
-
-        return [
-            `the repository still has ${state.repositoryHiddenRefCount} reachable ref(s) outside the canonical base: ${visibleRefs}${suffix}.`,
-        ];
-    }
-
-    return [
-        'the repository does not contain reachable refs outside the canonical base.',
-    ];
-}
-
 function buildRemoteReasonDetails(
     branch: string,
     baseShort: string,
@@ -5833,7 +5618,7 @@ function readRemoteReasonDetail(
         live_tip_unverified: `the live origin branch ${remoteName} could not be verified against the local remote-tracking ref. Fetch origin before manual remote cleanup.`,
         non_origin_upstream: `the branch tracks ${remoteName}, but only origin’s default branch is treated as canonical history.`,
         protected_base: `the tracked origin branch ${remoteName} is the canonical default branch and is protected from deletion.`,
-        safe: `the live origin branch ${remoteName} matches the local tracking ref, is already reachable from ${baseShort}, and can be auto-archived out of the active branch namespace while preserving its reflog.`,
+        safe: `the live origin branch ${remoteName} matches the local tracking ref and is already reachable from ${baseShort}.`,
         tracking_ref_not_on_base: `the live origin branch ${remoteName} is gone, but the remaining local origin-tracking ref is still not reachable from ${baseShort}.`,
     };
 
@@ -6627,6 +6412,7 @@ function buildApplyResultFromFinalState(
     const remoteBackupRef = readReportedRemoteBackupRef(remoteBranch);
     const localBranchStillAbsent = !branchRefExists(repoRoot, branchName);
     const remoteBranchStillAbsent = remoteDeleteTargetStillAbsent(
+        repoRoot,
         branch,
         remoteBranch,
     );
@@ -6642,14 +6428,10 @@ function buildApplyResultFromFinalState(
             localBranch.skippedReason,
         ) && finalProofValid;
     const remoteBranchDeleted =
-        branchDeleteSucceededCleanly(
-            remoteBranch.deleted,
-            remoteBranch.archivedSha ?? null,
-            remoteBranch.backupRef,
+        remoteBranchDeleteSucceededCleanly(
+            remoteBranch,
             remoteBackupRef,
             remoteBranchStillAbsent,
-            remoteBranch.errors,
-            remoteBranch.skippedReason,
         ) &&
         finalProofValid &&
         localBranchStillAbsent;
@@ -6738,22 +6520,55 @@ function readFinalReportedRemoteArchiveIssue(
         return null;
     }
 
-    if (
-        remoteBranch.backupRepoPath === undefined ||
-        remoteBranch.backupRepoPath === null ||
-        remoteBranch.backupRef === null ||
-        branch.remoteBranch === null
-    ) {
+    return remoteDeleteResultIsHostedDelete(remoteBranch)
+        ? readFinalHostedRemoteDeletionIssue(repoRoot, base, branch)
+        : readFinalArchivedRemoteBranchIssue(
+              repoRoot,
+              base,
+              branch,
+              remoteBranch,
+          );
+}
+
+function readFinalHostedRemoteDeletionIssue(
+    repoRoot: string,
+    base: BaseRef,
+    branch: BranchReport,
+): null | string {
+    if (branch.remoteBranch === null) {
+        return 'final hosted remote deletion revalidation failed: the original remote branch could not be identified.';
+    }
+
+    const issue = readHostedRemoteDeleteFinalIssue(
+        repoRoot,
+        base,
+        branch.remoteBranch,
+    );
+
+    return issue === null
+        ? null
+        : `final hosted remote deletion revalidation failed: ${issue}`;
+}
+
+function readFinalArchivedRemoteBranchIssue(
+    repoRoot: string,
+    base: BaseRef,
+    branch: BranchReport,
+    remoteBranch: RemoteDeleteResult,
+): null | string {
+    const recordedArchive = readRecordedRemoteArchive(remoteBranch);
+
+    if (recordedArchive === null || branch.remoteBranch === null) {
         return 'final remote archive proof revalidation failed: the remote branch archive was not fully recorded.';
     }
 
-    const archiveBranchName = remoteBranch.backupRef.replace(
+    const archiveBranchName = recordedArchive.backupRef.replace(
         /^refs\/heads\//u,
         '',
     );
     const issue = readFinalRemoteArchiveIssue(
         repoRoot,
-        remoteBranch.backupRepoPath,
+        recordedArchive.backupRepoPath,
         base,
         branch.remoteBranch,
         archiveBranchName,
@@ -6815,17 +6630,65 @@ function readFinalApplyProofIssue(
 }
 
 function remoteDeleteTargetStillAbsent(
+    repoRoot: string,
     branch: BranchReport,
     remoteBranch: RemoteDeleteResult,
 ): boolean {
     const remoteRepoPath = remoteBranch.backupRepoPath;
     const remoteBranchName = branch.remoteBranch?.branch;
 
+    if (
+        remoteDeleteResultIsHostedDelete(remoteBranch) &&
+        remoteBranchName !== undefined
+    ) {
+        return (
+            readLiveOriginBranchProbe(repoRoot, remoteBranchName).kind ===
+            'absent'
+        );
+    }
+
     return (
         remoteRepoPath !== undefined &&
         remoteRepoPath !== null &&
         remoteBranchName !== undefined &&
         !branchRefExists(remoteRepoPath, remoteBranchName)
+    );
+}
+
+function remoteBranchDeleteSucceededCleanly(
+    remoteBranch: RemoteDeleteResult,
+    reportedBackupRef: null | string,
+    branchStillAbsent: boolean,
+): boolean {
+    if (remoteDeleteResultIsHostedDelete(remoteBranch)) {
+        return (
+            branchStillAbsent &&
+            remoteBranch.errors.length === 0 &&
+            remoteBranch.skippedReason === null
+        );
+    }
+
+    return branchDeleteSucceededCleanly(
+        remoteBranch.deleted,
+        remoteBranch.archivedSha ?? null,
+        remoteBranch.backupRef,
+        reportedBackupRef,
+        branchStillAbsent,
+        remoteBranch.errors,
+        remoteBranch.skippedReason,
+    );
+}
+
+function remoteDeleteResultIsHostedDelete(
+    remoteBranch: RemoteDeleteResult,
+): boolean {
+    return (
+        remoteBranch.deleted &&
+        remoteBranch.archivedSha !== undefined &&
+        remoteBranch.archivedSha !== null &&
+        remoteBranch.backupRef === null &&
+        (remoteBranch.backupRepoPath === undefined ||
+            remoteBranch.backupRepoPath === null)
     );
 }
 
@@ -6983,10 +6846,34 @@ function restoreRemoteBranchFromResult(
 function readRemoteArchiveResultIssue(
     remoteBranch: RemoteDeleteResult,
 ): null | string {
-    if (!remoteBranch.deleted) {
+    if (
+        !remoteBranch.deleted ||
+        remoteDeleteResultIsHostedDelete(remoteBranch)
+    ) {
         return null;
     }
 
+    const recordedArchive = readRecordedRemoteArchive(remoteBranch);
+
+    if (recordedArchive === null) {
+        return 'the remote branch archive was not fully recorded.';
+    }
+
+    const validatedRemoteBackupRef = readValidatedBranchBackupRef(
+        recordedArchive.backupRepoPath,
+        recordedArchive.backupRef,
+        recordedArchive.archivedSha,
+        recordedArchive.backupReflogPrefix,
+    );
+
+    return validatedRemoteBackupRef === null
+        ? 'the remote branch archive ref could not be revalidated.'
+        : null;
+}
+
+function readRecordedRemoteArchive(
+    remoteBranch: RemoteDeleteResult,
+): null | RecordedRemoteArchive {
     if (
         remoteBranch.backupRepoPath === undefined ||
         remoteBranch.backupRepoPath === null ||
@@ -6996,19 +6883,15 @@ function readRemoteArchiveResultIssue(
         remoteBranch.backupReflogPrefix === undefined ||
         remoteBranch.backupReflogPrefix === null
     ) {
-        return 'the remote branch archive was not fully recorded.';
+        return null;
     }
 
-    const validatedRemoteBackupRef = readValidatedBranchBackupRef(
-        remoteBranch.backupRepoPath,
-        remoteBranch.backupRef,
-        remoteBranch.archivedSha,
-        remoteBranch.backupReflogPrefix,
-    );
-
-    return validatedRemoteBackupRef === null
-        ? 'the remote branch archive ref could not be revalidated.'
-        : null;
+    return {
+        archivedSha: remoteBranch.archivedSha,
+        backupRef: remoteBranch.backupRef,
+        backupReflogPrefix: remoteBranch.backupReflogPrefix,
+        backupRepoPath: remoteBranch.backupRepoPath,
+    };
 }
 
 function buildApplyExceptionResult(
@@ -8802,9 +8685,7 @@ function readPostArchiveRepositorySafetyIssue(
     try {
         const baseIssue = readLiveBaseValidationIssue(repoPath, base);
 
-        return (
-            baseIssue ?? readRepositoryWideSafetyIssue(repoPath, base.liveSha)
-        );
+        return baseIssue ?? readHistoryRewriteOverlayIssue(repoPath);
     } catch (error) {
         return readUnknownErrorMessage(error);
     }
@@ -9529,6 +9410,16 @@ function deleteRemoteBranch(
         return buildRemoteDeleteSkippedResult(localArchiveIssue);
     }
 
+    const hostedRemoteDelete = deleteHostedRemoteBranchIfEligible(
+        repoRoot,
+        base,
+        branch,
+    );
+
+    if (hostedRemoteDelete !== null) {
+        return hostedRemoteDelete;
+    }
+
     const remoteArchivePreparation = prepareRemoteArchive(
         repoRoot,
         base,
@@ -9544,6 +9435,219 @@ function deleteRemoteBranch(
               remoteArchivePreparation.latestBase,
               remoteArchivePreparation.remoteBranch,
               remoteArchivePreparation.liveSha,
+          );
+}
+
+function deleteHostedRemoteBranchIfEligible(
+    repoRoot: string,
+    base: BaseRef,
+    branch: BranchReport,
+): null | RemoteDeleteResult {
+    const remoteBranch = branch.remoteBranch;
+
+    if (
+        remoteBranch === null ||
+        originGitDirectoryIsLocallyInspectable(repoRoot, base)
+    ) {
+        return null;
+    }
+
+    if (remoteBranch.status === 'absent') {
+        return buildRemoteDeleteSkippedResult(
+            `the live origin branch ${remoteBranch.shortName} is already absent; no remote deletion was needed.`,
+            null,
+            true,
+        );
+    }
+
+    if (!isRemoteBranchSafeToDelete(branch.name, remoteBranch)) {
+        return buildRemoteDeleteSkippedResult(
+            'the origin branch does not pass the automatic hosted remote-deletion safety checks.',
+        );
+    }
+
+    return deleteHostedRemoteBranch(repoRoot, base, remoteBranch);
+}
+
+function deleteHostedRemoteBranch(
+    repoRoot: string,
+    base: BaseRef,
+    remoteBranch: RemoteBranchAssessment,
+): RemoteDeleteResult {
+    const latestBaseValidation = readHostedRemoteDeleteBaseValidation(
+        repoRoot,
+        base,
+    );
+
+    if (latestBaseValidation.status === 'blocked') {
+        return latestBaseValidation.result;
+    }
+
+    const validation = readHostedRemoteDeleteValidation(
+        repoRoot,
+        latestBaseValidation.base,
+        remoteBranch,
+    );
+
+    return validation.status === 'blocked'
+        ? validation.result
+        : pushHostedRemoteBranchDelete(
+              repoRoot,
+              latestBaseValidation.base,
+              remoteBranch,
+              validation.liveSha,
+          );
+}
+
+function readHostedRemoteDeleteBaseValidation(
+    repoRoot: string,
+    base: BaseRef,
+): HostedRemoteDeleteBaseValidation {
+    try {
+        return {
+            base: detectBaseRef(repoRoot, base.ref, base.remoteUrl, base),
+            status: 'ready',
+        };
+    } catch (error) {
+        return {
+            result: buildRemoteDeleteSkippedResult(
+                `origin could not be revalidated before hosted remote deletion: ${readUnknownErrorMessage(error)}`,
+            ),
+            status: 'blocked',
+        };
+    }
+}
+
+function readHostedRemoteDeleteValidation(
+    repoRoot: string,
+    latestBase: BaseRef,
+    remoteBranch: RemoteBranchAssessment,
+): HostedRemoteDeleteValidation {
+    const liveBranchState = readRemoteArchiveLiveBranchState(
+        repoRoot,
+        latestBase.shortName,
+        remoteBranch,
+    );
+
+    if (liveBranchState.status !== 'ready') {
+        return liveBranchState;
+    }
+
+    if (liveBranchState.liveSha !== remoteBranch.liveSha) {
+        return {
+            result: buildRemoteDeleteSkippedResult(
+                `the live origin branch ${remoteBranch.shortName} moved from ${remoteBranch.liveSha?.slice(0, 7) ?? 'unknown'} to ${liveBranchState.liveSha.slice(0, 7)} before deletion.`,
+            ),
+            status: 'blocked',
+        };
+    }
+
+    const latestLocalTrackingSha = readTrackedRemoteSha(
+        repoRoot,
+        remoteBranch.shortName,
+    );
+    const latestRemoteStatus = readOriginRemoteBranchStatus(
+        repoRoot,
+        latestBase,
+        remoteBranch.branch,
+        remoteBranch.shortName,
+        liveBranchState.liveBranchProbe,
+        latestLocalTrackingSha,
+    );
+
+    if (latestRemoteStatus !== 'safe') {
+        return {
+            result: buildRemoteDeleteSkippedResult(
+                readRemoteDeleteSkippedReason(
+                    latestBase.shortName,
+                    remoteBranch.shortName,
+                    latestRemoteStatus,
+                ),
+            ),
+            status: 'blocked',
+        };
+    }
+
+    return liveBranchState;
+}
+
+function pushHostedRemoteBranchDelete(
+    repoRoot: string,
+    latestBase: BaseRef,
+    remoteBranch: RemoteBranchAssessment,
+    liveSha: string,
+): RemoteDeleteResult {
+    const deleteResult = tryGit(repoRoot, [
+        'push',
+        'origin',
+        `--force-with-lease=refs/heads/${remoteBranch.branch}:${liveSha}`,
+        `:refs/heads/${remoteBranch.branch}`,
+    ]);
+
+    if (!deleteResult.ok) {
+        return {
+            backupRef: null,
+            deleted: false,
+            errors: [
+                `remote branch ${remoteBranch.shortName}: ${deleteResult.error}`,
+            ],
+            skippedReason: null,
+        };
+    }
+
+    const finalIssue = readHostedRemoteDeleteFinalIssue(
+        repoRoot,
+        latestBase,
+        remoteBranch,
+    );
+
+    return finalIssue === null
+        ? {
+              archivedSha: liveSha,
+              backupRef: null,
+              backupRepoPath: null,
+              deleted: true,
+              errors: [],
+              skippedReason: null,
+          }
+        : {
+              archivedSha: null,
+              backupRef: null,
+              backupRepoPath: null,
+              deleted: false,
+              errors: [
+                  `remote branch ${remoteBranch.shortName}: ${finalIssue}`,
+              ],
+              skippedReason: null,
+          };
+}
+
+function readHostedRemoteDeleteFinalIssue(
+    repoRoot: string,
+    latestBase: BaseRef,
+    remoteBranch: RemoteBranchAssessment,
+): null | string {
+    const headIssue = readRemoteArchiveHeadSkippedReason(repoRoot, latestBase);
+
+    if (headIssue !== null) {
+        return headIssue;
+    }
+
+    const liveBranchProbe = readLiveOriginBranchProbe(
+        repoRoot,
+        remoteBranch.branch,
+    );
+
+    if (liveBranchProbe.kind === 'absent') {
+        return null;
+    }
+
+    return liveBranchProbe.kind === 'present'
+        ? `the live origin branch ${remoteBranch.shortName} still exists after delete.`
+        : readRemoteDeleteSkippedReason(
+              latestBase.shortName,
+              remoteBranch.shortName,
+              'live_probe_unverified',
           );
 }
 
@@ -10604,7 +10708,107 @@ function renderReport(report: GitCleanupReport): string {
         ...renderReportSection('## Skipped', skippedSections),
         ...renderReportSection('## Detached Worktrees', detachedSections),
         ...renderArchivePruneSection(report),
+        ...renderActionSummarySection(report),
     ].join('\n');
+}
+
+function renderActionSummarySection(report: GitCleanupReport): string[] {
+    return renderReportSection('## Action Summary', [
+        renderActionSummary(report),
+    ]);
+}
+
+function renderActionSummary(report: GitCleanupReport): string {
+    return [
+        ...renderApplyResultsActionSummary(report.applyResults),
+        ...renderArchivePruneActionSummary(report.archivePruneResults),
+        renderSafeDeleteActionSummary(report.branches.safeDelete),
+        ...renderApplyCommandActionSummary(report.branches.safeDelete),
+        renderNeedsReviewActionSummary(report.branches.needsReview),
+        renderDetachedWorktreeActionSummary(report.detachedWorktrees),
+    ].join('\n');
+}
+
+function renderApplyResultsActionSummary(
+    applyResults: readonly ApplyResult[] | undefined,
+): string[] {
+    if (applyResults === undefined) {
+        return [];
+    }
+
+    if (applyResults.length === 0) {
+        return ['- Applied deletes: none.'];
+    }
+
+    return [
+        `- Applied deletes: ${applyResults.map(renderApplyResultActionSummary).join('; ')}.`,
+    ];
+}
+
+function renderApplyResultActionSummary(applyResult: ApplyResult): string {
+    const localStatus = applyResult.localBranchDeleted
+        ? 'local deleted'
+        : 'local kept';
+    const remoteStatus = applyResult.remoteBranchDeleted
+        ? 'origin deleted'
+        : 'origin kept';
+    const errorStatus =
+        applyResult.errors.length === 0
+            ? ''
+            : `, ${applyResult.errors.length} error(s)`;
+
+    return `\`${applyResult.branch}\` (${localStatus}, ${remoteStatus}${errorStatus})`;
+}
+
+function renderArchivePruneActionSummary(
+    archivePruneResults: readonly ArchivePruneResult[] | undefined,
+): string[] {
+    if (archivePruneResults === undefined) {
+        return [];
+    }
+
+    const prunedCount = archivePruneResults.filter(
+        (result) => result.pruned,
+    ).length;
+    const keptCount = archivePruneResults.length - prunedCount;
+
+    return [`- Archive pruning: ${prunedCount} pruned, ${keptCount} kept.`];
+}
+
+function renderSafeDeleteActionSummary(
+    safeDeleteBranches: readonly BranchReport[],
+): string {
+    return `- Delete candidates: ${renderBranchNameList(safeDeleteBranches)}.`;
+}
+
+function renderApplyCommandActionSummary(
+    safeDeleteBranches: readonly BranchReport[],
+): string[] {
+    return safeDeleteBranches.length === 0
+        ? []
+        : ['- To delete them: `slop-refinery git-cleanup --apply`.'];
+}
+
+function renderNeedsReviewActionSummary(
+    needsReviewBranches: readonly BranchReport[],
+): string {
+    return `- Manual review: ${renderBranchNameList(needsReviewBranches)}.`;
+}
+
+function renderBranchNameList(branches: readonly { name: string }[]): string {
+    return branches.length === 0
+        ? 'none'
+        : branches.map((branch) => `\`${branch.name}\``).join(', ');
+}
+
+function renderDetachedWorktreeActionSummary(
+    detachedWorktrees: readonly DetachedWorktreeReport[],
+): string {
+    const count = detachedWorktrees.length;
+
+    return count === 0
+        ? '- Detached worktrees: none.'
+        : `- Detached worktrees needing review: ${count}.`;
 }
 
 function renderArchivePruneSummary(report: GitCleanupReport): string[] {

--- a/src/lib/git-cleanup.ts
+++ b/src/lib/git-cleanup.ts
@@ -4066,14 +4066,33 @@ function assessBranchWithoutOriginUpstream(
         liveBranchProbe,
         localTrackingSha,
     );
+    const remoteSafetyProofFingerprint =
+        status === 'safe' || status === 'absent'
+            ? readRemoteSafetyProofFingerprint(
+                  repoRoot,
+                  base,
+                  branch,
+                  shortName,
+                  localTrackingSha,
+              )
+            : null;
+    const localTrackingProofFingerprint =
+        status === 'safe' || status === 'absent'
+            ? readSafeLocalTrackingProofFingerprint(
+                  repoRoot,
+                  base,
+                  shortName,
+                  localTrackingSha,
+              )
+            : null;
 
     return {
         branch,
         liveSha,
-        localTrackingProofFingerprint: null,
+        localTrackingProofFingerprint,
         localTrackingSha,
         remote: 'origin',
-        remoteSafetyProofFingerprint: null,
+        remoteSafetyProofFingerprint,
         shortName,
         status,
     };
@@ -4315,10 +4334,36 @@ function readPresentOriginRemoteBranchStatus(
         return liveTipStatus;
     }
 
+    const trackingIdentityStatus = readLocalTrackingRefIdentityStatus(
+        repoRoot,
+        trackingShortName,
+        liveSha,
+    );
+
+    if (trackingIdentityStatus !== 'safe') {
+        return trackingIdentityStatus;
+    }
+
     if (!originGitDirectoryIsLocallyInspectable(repoRoot, base)) {
         return 'safe';
     }
 
+    return readInspectablePresentOriginRemoteBranchStatus(
+        repoRoot,
+        base,
+        branch,
+        trackingShortName,
+        liveSha,
+    );
+}
+
+function readInspectablePresentOriginRemoteBranchStatus(
+    repoRoot: string,
+    base: BaseRef,
+    branch: string,
+    trackingShortName: string,
+    liveSha: string,
+): RemoteBranchStatus {
     const trackingStatus = readLocalTrackingRefStatus(
         repoRoot,
         base,
@@ -4378,6 +4423,25 @@ function readPresentOriginLiveTipStatus(
     ])
         ? 'safe'
         : 'live_tip_not_on_base';
+}
+
+function readLocalTrackingRefIdentityStatus(
+    repoRoot: string,
+    trackingShortName: string,
+    expectedSha: string,
+): Extract<
+    RemoteBranchStatus,
+    'identity_unverified' | 'live_tip_unverified' | 'safe'
+> {
+    const trackingRef = `refs/remotes/${trackingShortName}`;
+
+    if (isSymbolicRef(repoRoot, trackingRef)) {
+        return 'identity_unverified';
+    }
+
+    return readRefCommitSha(repoRoot, trackingRef) === expectedSha
+        ? 'safe'
+        : 'live_tip_unverified';
 }
 
 function originGitDirectoryIsLocallyInspectable(
@@ -7399,16 +7463,130 @@ function readSafeWithoutDeleteRemoteIssue(
         return 'remote cleanup did not archive the origin branch after the local archive.';
     }
 
-    const absentArchive = prepareAbsentRemoteArchive(
+    return readAbsentRemoteSafeWithoutDeleteIssue(
         repoRoot,
         base,
         branch.remoteBranch,
     );
+}
 
-    return absentArchive.status === 'blocked' &&
-        absentArchive.result.safeWithoutDelete === true
+function readAbsentRemoteSafeWithoutDeleteIssue(
+    repoRoot: string,
+    base: BaseRef,
+    remoteBranch: RemoteBranchAssessment,
+): null | string {
+    const validation = readAbsentRemoteSafeWithoutDeleteValidation(
+        repoRoot,
+        base,
+        remoteBranch,
+    );
+
+    return validation === null
         ? null
-        : `the absent origin branch proof changed after the local archive (${absentArchive.status === 'blocked' ? (absentArchive.result.skippedReason ?? 'remote cleanup was skipped') : 'remote cleanup became archiveable'})`;
+        : `the absent origin branch proof changed after the local archive (${validation})`;
+}
+
+function readAbsentRemoteSafeWithoutDeleteValidation(
+    repoRoot: string,
+    base: BaseRef,
+    remoteBranch: RemoteBranchAssessment,
+): null | string {
+    const latestBase = readAbsentRemoteSafeWithoutDeleteBase(repoRoot, base);
+
+    if (typeof latestBase === 'string') {
+        return latestBase;
+    }
+
+    const liveBranchProbe = readLiveOriginBranchProbe(
+        repoRoot,
+        remoteBranch.branch,
+    );
+    const latestLocalTrackingSha = readTrackedRemoteSha(
+        repoRoot,
+        remoteBranch.shortName,
+    );
+    const latestRemoteStatus = readOriginRemoteBranchStatus(
+        repoRoot,
+        latestBase,
+        remoteBranch.branch,
+        remoteBranch.shortName,
+        liveBranchProbe,
+        latestLocalTrackingSha,
+    );
+
+    if (latestRemoteStatus !== 'absent') {
+        return readAbsentRemoteStatusChangedIssue(
+            latestBase,
+            remoteBranch,
+            latestRemoteStatus,
+        );
+    }
+
+    return readAbsentRemoteProofChangeIssue(
+        repoRoot,
+        latestBase,
+        remoteBranch,
+        latestLocalTrackingSha,
+    );
+}
+
+function readAbsentRemoteSafeWithoutDeleteBase(
+    repoRoot: string,
+    base: BaseRef,
+): BaseRef | string {
+    try {
+        return detectBaseRef(repoRoot, base.ref, base.remoteUrl, base);
+    } catch (error) {
+        return `origin could not be revalidated: ${readUnknownErrorMessage(error)}`;
+    }
+}
+
+function readAbsentRemoteStatusChangedIssue(
+    latestBase: BaseRef,
+    remoteBranch: RemoteBranchAssessment,
+    latestRemoteStatus: Exclude<RemoteBranchStatus, 'absent'>,
+): string {
+    return latestRemoteStatus === 'safe'
+        ? `the live origin branch ${remoteBranch.shortName} reappeared before final validation`
+        : readRemoteDeleteSkippedReason(
+              latestBase.shortName,
+              remoteBranch.shortName,
+              latestRemoteStatus,
+          );
+}
+
+function readAbsentRemoteProofChangeIssue(
+    repoRoot: string,
+    latestBase: BaseRef,
+    remoteBranch: RemoteBranchAssessment,
+    latestLocalTrackingSha: null | string,
+): null | string {
+    const trackingIssue = readRemoteArchiveLocalTrackingProofIssue(
+        repoRoot,
+        latestBase,
+        remoteBranch,
+    );
+
+    if (trackingIssue !== null) {
+        return trackingIssue;
+    }
+
+    if (remoteBranch.remoteSafetyProofFingerprint === null) {
+        return null;
+    }
+
+    const latestRemoteSafetyProofFingerprint = readRemoteSafetyProofFingerprint(
+        repoRoot,
+        latestBase,
+        remoteBranch.branch,
+        remoteBranch.shortName,
+        latestLocalTrackingSha,
+    );
+
+    return latestRemoteSafetyProofFingerprint ===
+        remoteBranch.remoteSafetyProofFingerprint
+        ? null
+        : `the remote safety proof for ${remoteBranch.shortName} changed`;
 }
 
 function buildRestoredLocalBranchAfterRemoteFailure(
@@ -9610,16 +9788,108 @@ function pushHostedRemoteBranchDelete(
               errors: [],
               skippedReason: null,
           }
-        : {
-              archivedSha: null,
-              backupRef: null,
-              backupRepoPath: null,
-              deleted: false,
-              errors: [
-                  `remote branch ${remoteBranch.shortName}: ${finalIssue}`,
+        : buildHostedRemoteDeleteFinalFailureResult(
+              repoRoot,
+              remoteBranch,
+              liveSha,
+              finalIssue,
+          );
+}
+
+function buildHostedRemoteDeleteFinalFailureResult(
+    repoRoot: string,
+    remoteBranch: RemoteBranchAssessment,
+    liveSha: string,
+    finalIssue: string,
+): RemoteDeleteResult {
+    const liveBranchProbe = readLiveOriginBranchProbe(
+        repoRoot,
+        remoteBranch.branch,
+    );
+
+    return liveBranchProbe.kind === 'absent'
+        ? restoreHostedRemoteBranchAfterIssue(
+              repoRoot,
+              remoteBranch,
+              liveSha,
+              finalIssue,
+          )
+        : buildHostedRemoteDeleteUnrestoredFailureResult(
+              remoteBranch,
+              liveSha,
+              finalIssue,
+              liveBranchProbe,
+          );
+}
+
+function buildHostedRemoteDeleteUnrestoredFailureResult(
+    remoteBranch: RemoteBranchAssessment,
+    liveSha: string,
+    finalIssue: string,
+    liveBranchProbe: LiveOriginBranchProbe,
+): RemoteDeleteResult {
+    const branchState =
+        liveBranchProbe.kind === 'present'
+            ? `still exists at ${liveBranchProbe.sha.slice(0, 7)}`
+            : 'could not be rechecked';
+
+    return {
+        archivedSha: liveSha,
+        backupRef: null,
+        backupRepoPath: null,
+        deleted: false,
+        errors: [
+            `remote branch ${remoteBranch.shortName}: ${finalIssue}; the branch ${branchState}.`,
+        ],
+        skippedReason: null,
+    };
+}
+
+function restoreHostedRemoteBranchAfterIssue(
+    repoRoot: string,
+    remoteBranch: RemoteBranchAssessment,
+    liveSha: string,
+    issue: string,
+): RemoteDeleteResult {
+    const restoreResult = tryGit(repoRoot, [
+        'push',
+        'origin',
+        `--force-with-lease=refs/heads/${remoteBranch.branch}:`,
+        `${liveSha}:refs/heads/${remoteBranch.branch}`,
+    ]);
+    const restored = restoreResult.ok
+        ? hostedRemoteBranchRestored(repoRoot, remoteBranch, liveSha)
+        : false;
+
+    return {
+        archivedSha: liveSha,
+        backupRef: null,
+        backupRepoPath: null,
+        deleted: false,
+        errors: restored
+            ? []
+            : [
+                  `remote branch ${remoteBranch.shortName}: ${issue}; git-cleanup could not restore the branch${restoreResult.ok ? '' : `: ${restoreResult.error}`}.`,
               ],
-              skippedReason: null,
-          };
+        skippedReason: restored
+            ? `${issue}, so the live origin branch was restored.`
+            : `${issue}, and git-cleanup could not restore ${remoteBranch.shortName}.`,
+    };
+}
+
+function hostedRemoteBranchRestored(
+    repoRoot: string,
+    remoteBranch: RemoteBranchAssessment,
+    liveSha: string,
+): boolean {
+    const liveBranchProbe = readLiveOriginBranchProbe(
+        repoRoot,
+        remoteBranch.branch,
+    );
+
+    return (
+        liveBranchProbe.kind === 'present' && liveBranchProbe.sha === liveSha
+    );
 }
 
 function readHostedRemoteDeleteFinalIssue(
@@ -9942,24 +10212,17 @@ function prepareAbsentRemoteArchive(
     );
 
     if (latestRemoteStatus === 'absent') {
-        const latestRemoteSafetyProofFingerprint =
-            readRemoteSafetyProofFingerprint(
-                repoRoot,
-                latestBase,
-                remoteBranch.branch,
-                remoteBranch.shortName,
-                latestLocalTrackingSha,
-            );
+        const proofIssue = readAbsentRemoteProofChangeIssue(
+            repoRoot,
+            latestBase,
+            remoteBranch,
+            latestLocalTrackingSha,
+        );
 
-        if (
-            remoteBranch.remoteSafetyProofFingerprint === null ||
-            latestRemoteSafetyProofFingerprint === null ||
-            latestRemoteSafetyProofFingerprint !==
-                remoteBranch.remoteSafetyProofFingerprint
-        ) {
+        if (proofIssue !== null) {
             return {
                 result: buildRemoteDeleteSkippedResult(
-                    `the remote safety proof for ${remoteBranch.shortName} changed before remote cleanup, so remote deletion was skipped.`,
+                    `${proofIssue} before remote cleanup, so remote deletion was skipped.`,
                 ),
                 status: 'blocked',
             };

--- a/src/lib/git-cleanup.ts
+++ b/src/lib/git-cleanup.ts
@@ -325,6 +325,7 @@ type Opinion = {
 
 type Options = {
     apply: boolean;
+    applyCommand?: string;
     base: null | string;
     json: boolean;
     keepArchives: boolean;
@@ -541,6 +542,7 @@ export type GitCleanupWorktreeInfo = WorktreeInfo;
 
 const BACKUP_SUFFIX_LENGTH = 8;
 const COMMIT_FORMAT = '%H%x1f%cI%x1f%an%x1f%s';
+const DEFAULT_APPLY_COMMAND = 'slop-refinery git-cleanup --apply';
 const GIT_ADMIN_DIRECTORIES = ['rebase-apply', 'rebase-merge', 'sequencer'];
 const GIT_ADMIN_FILES = [
     'AUTO_MERGE',
@@ -1239,6 +1241,7 @@ export function renderGitCleanupOutput(
 function parseArgs(args: readonly string[]): Options {
     return parseArgsFromIndex(args, 0, {
         apply: false,
+        applyCommand: DEFAULT_APPLY_COMMAND,
         base: null,
         json: false,
         keepArchives: false,
@@ -1398,6 +1401,7 @@ function buildReportContext(options: Options): GitCleanupReportContext {
         hiddenRefAnalysis,
         repositoryReflogAnalysis,
         unreachableCommitAnalysis,
+        options.applyCommand ?? DEFAULT_APPLY_COMMAND,
     );
     const finalBaseIssue = readLiveBaseValidationIssue(repoRoot, base);
     const revalidatedBranches =
@@ -2094,6 +2098,10 @@ function reconcileApplyReportBranches(
             applyResult,
         );
 
+        if (reconciledBranch === null) {
+            continue;
+        }
+
         if (reconciledBranch.classification === 'safe_delete') {
             safeDelete.push(reconciledBranch);
         } else {
@@ -2113,12 +2121,9 @@ function reconcileSafeDeleteBranchAfterApply(
     base: BaseRef,
     branch: BranchReport,
     applyResult: ApplyResult | undefined,
-): BranchReport {
+): BranchReport | null {
     if (applyResultCompletedLocalDeletion(applyResult)) {
-        return convertAppliedSafeDeleteBranchToPostApplyReport(
-            branch,
-            applyResult,
-        );
+        return null;
     }
 
     if (!branchRefExists(repoRoot, branch.name)) {
@@ -2161,55 +2166,6 @@ function applyResultCompletedLocalDeletion(
         result.errors.length === 0 &&
         result.localBranchDeleted
     );
-}
-
-function convertAppliedSafeDeleteBranchToPostApplyReport(
-    branch: BranchReport,
-    applyResult: ApplyResult,
-): BranchReport {
-    const remoteBranch = applyResult.remoteBranchDeleted
-        ? readArchivedRemoteBranchPostApplyState(branch.remoteBranch)
-        : branch.remoteBranch;
-    const originBranchStatus = applyResult.remoteBranchDeleted
-        ? 'absent'
-        : branch.state.originBranchStatus;
-
-    return {
-        ...branch,
-        classification: 'needs_review',
-        deleteCommands: [],
-        opinion: {
-            code: 'keep_for_review',
-            label: 'apply completed',
-            reason: `git-cleanup already archived ${branch.name} during --apply, so no further delete command is emitted for the stale branch name.`,
-        },
-        reasonDetails: [
-            ...branch.reasonDetails,
-            `git-cleanup --apply already archived ${branch.name}; this post-apply report intentionally omits delete guidance for the stale branch name.`,
-        ],
-        remoteBranch,
-        state: {
-            ...branch.state,
-            originBranchStatus,
-            safeToDelete: false,
-            safetyProofFingerprint: null,
-        },
-    };
-}
-
-function readArchivedRemoteBranchPostApplyState(
-    remoteBranch: null | RemoteBranchAssessment,
-): null | RemoteBranchAssessment {
-    return remoteBranch === null
-        ? null
-        : {
-              ...remoteBranch,
-              liveSha: null,
-              localTrackingProofFingerprint: null,
-              localTrackingSha: null,
-              remoteSafetyProofFingerprint: null,
-              status: 'absent',
-          };
 }
 
 function readApplyResultIssue(
@@ -3622,6 +3578,7 @@ function buildBranchBuckets(
     hiddenRefAnalysis: HiddenRefAnalysis,
     repositoryReflogAnalysis: ReflogAnalysis,
     unreachableCommitAnalysis: RepositoryUnreachableCommitAnalysis,
+    applyCommand: string,
 ): BranchBuckets {
     const skipped: SkippedBranchReport[] = [];
     const safeDelete: BranchReport[] = [];
@@ -3637,6 +3594,7 @@ function buildBranchBuckets(
             hiddenRefAnalysis,
             repositoryReflogAnalysis,
             unreachableCommitAnalysis,
+            applyCommand,
         );
 
         if (branch === base.branchName) {
@@ -3709,6 +3667,7 @@ function buildBranchReport(
     hiddenRefAnalysis: HiddenRefAnalysis,
     repositoryReflogAnalysis: ReflogAnalysis,
     unreachableCommitAnalysis: RepositoryUnreachableCommitAnalysis,
+    applyCommand = DEFAULT_APPLY_COMMAND,
 ): BranchReport {
     const linkedWorktrees = worktrees.filter(
         (worktree) => worktree.branchName === branch,
@@ -3756,6 +3715,7 @@ function buildBranchReport(
             linkedWorktrees,
             remoteBranch,
             state,
+            applyCommand,
         ),
         linkedWorktrees,
         name: branch,
@@ -5313,13 +5273,14 @@ function buildDeleteCommands(
     _linkedWorktrees: readonly WorktreeInfo[],
     remoteBranch: null | RemoteBranchAssessment,
     state: BranchState,
+    applyCommand: string,
 ): string[] {
     if (!state.safeToDelete) {
         return [];
     }
 
     const commands = [
-        `slop-refinery git-cleanup --apply # revalidate and archive ${shellQuote(branch)} safely`,
+        `${applyCommand} # revalidate and archive ${shellQuote(branch)} safely`,
     ];
 
     if (remoteBranch !== null) {
@@ -11047,15 +11008,39 @@ function renderSafeDeleteActionSummary(
 function renderApplyCommandActionSummary(
     safeDeleteBranches: readonly BranchReport[],
 ): string[] {
-    return safeDeleteBranches.length === 0
+    const applyCommand = readApplyCommandFromBranches(safeDeleteBranches);
+
+    return applyCommand === null
         ? []
-        : ['- To delete them: `slop-refinery git-cleanup --apply`.'];
+        : [`- To delete them: \`${applyCommand}\`.`];
 }
 
 function renderNeedsReviewActionSummary(
     needsReviewBranches: readonly BranchReport[],
 ): string {
     return `- Manual review: ${renderBranchNameList(needsReviewBranches)}.`;
+}
+
+function readApplyCommandFromBranches(
+    branches: readonly BranchReport[],
+): null | string {
+    for (const branch of branches) {
+        const [deleteCommand] = branch.deleteCommands;
+
+        if (deleteCommand !== undefined) {
+            return stripDeleteCommandComment(deleteCommand);
+        }
+    }
+
+    return null;
+}
+
+function stripDeleteCommandComment(deleteCommand: string): string {
+    const commentStart = deleteCommand.indexOf(' # revalidate and archive ');
+
+    return commentStart === -1
+        ? deleteCommand
+        : deleteCommand.slice(0, commentStart);
 }
 
 function renderBranchNameList(branches: readonly { name: string }[]): string {

--- a/tests/git-cleanup.test.ts
+++ b/tests/git-cleanup.test.ts
@@ -173,6 +173,21 @@ function configureFixtureClone(repoClonePath: string): void {
     configureFixtureHistoryRetention(repoClonePath);
 }
 
+function makeOriginAppearHosted(fixture: GitFixture): string {
+    const hostedOriginUrl = `ssh://git@example.test/${path.basename(
+        fixture.tempPath,
+    )}/origin.git`;
+
+    git(fixture.repoPath, ['remote', 'set-url', 'origin', hostedOriginUrl]);
+    git(
+        fixture.repoPath,
+        ['config', `url.${fixture.originPath}.insteadOf`, hostedOriginUrl],
+        false,
+    );
+
+    return hostedOriginUrl;
+}
+
 function configureFixtureHistoryRetention(cwd: string): void {
     git(cwd, ['config', 'core.logAllRefUpdates', 'always'], false);
     git(cwd, ['config', 'gc.reflogExpire', 'never'], false);
@@ -241,6 +256,18 @@ function createMergedFeatureBranch(
     git(cwd, ['checkout', 'main'], false);
     git(cwd, ['merge', '--ff-only', branchName], false);
     git(cwd, ['push', 'origin', 'main'], false);
+}
+
+function createUnmergedRemoteBranch(cwd: string, branchName: string): void {
+    git(cwd, ['checkout', '-b', branchName], false);
+    commitFile(
+        cwd,
+        `${branchName}.txt`,
+        `${branchName}\n`,
+        `Add ${branchName} work`,
+    );
+    git(cwd, ['push', '-u', 'origin', branchName], false);
+    git(cwd, ['checkout', 'main'], false);
 }
 
 function createHiddenLocalRefNotOnBase(cwd: string, refName: string): void {
@@ -598,6 +625,23 @@ function ensurePresent<T>(value: null | T, message: string): T {
     throw new Error(message);
 }
 
+function expectRemoteArchiveTransactionFailedWithoutArchive(
+    fixture: GitFixture,
+    archiveResult: ReturnType<typeof archiveBranchRefTransactionForTesting>,
+    featureSha: string,
+    archiveBranchName: string,
+): void {
+    expect(archiveResult.ok).toBe(false);
+    expect(readCurrentSha(fixture.originPath, 'feature')).toBe(featureSha);
+    expect(
+        git(fixture.originPath, [
+            'for-each-ref',
+            `refs/heads/${archiveBranchName}`,
+            '--format=%(refname:short)',
+        ]),
+    ).toBe('');
+}
+
 function expectFeatureDeletedLocallyAndRemotely(
     fixture: GitFixture,
     applyResult:
@@ -632,6 +676,35 @@ function expectFeatureDeletedLocallyAndRemotely(
     expect(applyResult?.remoteBackupRef).toBe(
         `refs/heads/${remoteArchiveBranch}`,
     );
+}
+
+function expectHostedFeatureDeletedLocallyAndRemotely(
+    fixture: GitFixture,
+    applyResult:
+        | NonNullable<GitCleanupReportType['applyResults']>[number]
+        | undefined,
+    remoteFeatureSha: string,
+): void {
+    const localArchiveBranch = ensurePresent(
+        findArchivedBranch(fixture.repoPath, 'local', 'feature'),
+        'Expected a local archived branch for feature.',
+    );
+
+    expect(applyResult?.localBranchDeleted).toBe(true);
+    expect(applyResult?.remoteBranchDeleted).toBe(true);
+    expect(applyResult?.remoteBranchSkippedReason).toBeNull();
+    expect(applyResult?.remoteBackupRef).toBeNull();
+    expect(git(fixture.repoPath, ['branch', '--list', 'feature'])).toBe('');
+    expect(
+        git(fixture.repoPath, ['ls-remote', 'origin', 'refs/heads/feature']),
+    ).toBe('');
+    expect(readCurrentSha(fixture.repoPath, localArchiveBranch)).toBe(
+        remoteFeatureSha,
+    );
+    expect(
+        findArchivedBranch(fixture.originPath, 'remote', 'feature'),
+    ).toBeNull();
+    expectArchivedBranchReflogExists(fixture.repoPath, localArchiveBranch);
 }
 
 function applyFeatureAndReadArchiveRefs(
@@ -791,6 +864,21 @@ function expectSafeDeleteCommandsUseGuardedApply(
     );
 }
 
+function expectSafeDeleteBranch(
+    report: GitCleanupReportType,
+    branchName = 'feature',
+): GitCleanupBranchReport {
+    const safeDeleteBranch = findBranchReport(report, 'safeDelete', branchName);
+
+    expect(safeDeleteBranch?.classification).toBe('safe_delete');
+
+    if (safeDeleteBranch === undefined) {
+        throw new Error(`Expected ${branchName} to be safe_delete.`);
+    }
+
+    return safeDeleteBranch;
+}
+
 function buildGitCleanupStressScenario(seed: number): GitCleanupStressScenario {
     const localModes: readonly GitCleanupStressLocalMode[] = [
         'clean',
@@ -912,8 +1000,9 @@ function expectGitCleanupStressInvariant(
         'needsReview',
         'feature',
     );
-    const expectedSafe =
-        scenario.localMode === 'clean' && scenario.remoteMode === 'clean';
+    const expectedSafe = ['absent_no_upstream', 'clean'].includes(
+        scenario.remoteMode,
+    );
 
     if (expectedSafe) {
         expect(safeDeleteBranch?.classification).toBe('safe_delete');
@@ -1649,23 +1738,6 @@ function installDirtyWorktreeAndGraftOnLocalArchiveHook(
     chmodSync(hookPath, 0o755);
 }
 
-function createDirtyLocalArchiveRestoreFixture(): {
-    featureSha: string;
-    fixture: GitFixture;
-} {
-    const fixture = createGitFixture();
-
-    createMergedFeatureBranch(fixture.repoPath, 'feature', {
-        pushRemote: true,
-    });
-    installDirtyWorktreeOnLocalArchiveHook(fixture);
-
-    return {
-        featureSha: readCurrentSha(fixture.repoPath, 'feature'),
-        fixture,
-    };
-}
-
 function expectLocalArchiveRestorePreservedBackup(
     fixture: GitFixture,
     featureSha: string,
@@ -2389,6 +2461,34 @@ const gitCleanupIntegrationTimeoutMs = 60_000;
 const gitCleanupLongIntegrationTimeoutMs = 180_000;
 
 describe('git-cleanup CLI', () => {
+    describe('human-readable output', () => {
+        it(
+            'ends human-readable audit output with a compact action summary',
+            () => {
+                const fixture = createGitFixture();
+
+                createMergedFeatureBranch(fixture.repoPath, 'feature', {
+                    pushRemote: true,
+                });
+                createUnmergedRemoteBranch(fixture.repoPath, 'review');
+                makeOriginAppearHosted(fixture);
+
+                const result = runGitCleanup(fixture.repoPath, ['git-cleanup']);
+                const expectedEnding = [
+                    '## Action Summary',
+                    '- Delete candidates: `feature`.',
+                    '- To delete them: `slop-refinery git-cleanup --apply`.',
+                    '- Manual review: `review`.',
+                    '- Detached worktrees: none.',
+                ].join('\n');
+
+                expect(result.status).toBe(0);
+                expect(result.output.endsWith(expectedEnding)).toBe(true);
+            },
+            gitCleanupIntegrationTimeoutMs,
+        );
+    });
+
     describe('branch and remote classification', () => {
         it(
             'marks a merged local branch safe_delete and prunes redundant archives after apply',
@@ -2526,7 +2626,7 @@ describe('git-cleanup CLI', () => {
 
         describe('final proof rechecks', () => {
             it(
-                'removes delete guidance when the final proof recheck demotes a branch',
+                'keeps delete guidance when unrelated hidden refs appear during the final proof recheck',
                 () => {
                     const fixture = createGitFixture();
 
@@ -2548,21 +2648,7 @@ describe('git-cleanup CLI', () => {
                         ['git-cleanup'],
                         env,
                     );
-                    const reviewBranch = findBranchReport(
-                        auditReport,
-                        'needsReview',
-                        'feature',
-                    );
-
-                    expect(reviewBranch?.classification).toBe('needs_review');
-                    expect(reviewBranch?.state.safeToDelete).toBe(false);
-                    expect(reviewBranch?.deleteCommands).toEqual([]);
-                    expect(reviewBranch?.opinion.code).toBe(
-                        'needs_human_review',
-                    );
-                    expect(
-                        findBranchReport(auditReport, 'safeDelete', 'feature'),
-                    ).toBe(undefined);
+                    expectSafeDeleteBranch(auditReport);
                 },
                 gitCleanupIntegrationTimeoutMs,
             );
@@ -2654,7 +2740,7 @@ describe('git-cleanup CLI', () => {
             );
 
             it(
-                'removes delete guidance when replace refs appear during the final repository proof recheck',
+                'keeps delete guidance when replace refs do not appear until after the branch proof recheck',
                 () => {
                     const fixture = createGitFixture();
 
@@ -2675,27 +2761,14 @@ describe('git-cleanup CLI', () => {
                         ['git-cleanup'],
                         env,
                     );
-                    const reviewBranch = findBranchReport(
-                        auditReport,
-                        'needsReview',
-                        'feature',
-                    );
 
-                    expect(reviewBranch?.classification).toBe('needs_review');
-                    expect(reviewBranch?.state.safeToDelete).toBe(false);
-                    expect(reviewBranch?.deleteCommands).toEqual([]);
-                    expect(reviewBranch?.reasonDetails.join('\n')).toContain(
-                        'refs/replace',
-                    );
-                    expect(
-                        findBranchReport(auditReport, 'safeDelete', 'feature'),
-                    ).toBe(undefined);
+                    expectSafeDeleteBranch(auditReport);
                 },
                 gitCleanupIntegrationTimeoutMs,
             );
 
             it(
-                'removes delete guidance when hidden refs appear during the final repository proof recheck',
+                'keeps delete guidance when hidden refs appear during the final repository proof recheck',
                 () => {
                     const fixture = createGitFixture();
 
@@ -2713,27 +2786,13 @@ describe('git-cleanup CLI', () => {
                         ['git-cleanup'],
                         env,
                     );
-                    const reviewBranch = findBranchReport(
-                        auditReport,
-                        'needsReview',
-                        'feature',
-                    );
-
-                    expect(reviewBranch?.classification).toBe('needs_review');
-                    expect(reviewBranch?.state.safeToDelete).toBe(false);
-                    expect(reviewBranch?.deleteCommands).toEqual([]);
-                    expect(reviewBranch?.reasonDetails.join('\n')).toContain(
-                        'repository gained 1 reachable ref',
-                    );
-                    expect(
-                        findBranchReport(auditReport, 'safeDelete', 'feature'),
-                    ).toBe(undefined);
+                    expectSafeDeleteBranch(auditReport);
                 },
                 gitCleanupIntegrationTimeoutMs,
             );
 
             it(
-                'removes delete guidance when a detached worktree appears during the final proof recheck',
+                'keeps delete guidance when a detached worktree appears during the final proof recheck',
                 () => {
                     const fixture = createGitFixture();
 
@@ -2748,21 +2807,14 @@ describe('git-cleanup CLI', () => {
                         ['git-cleanup'],
                         env,
                     );
-                    const reviewBranch = findBranchReport(
-                        auditReport,
-                        'needsReview',
-                        'feature',
-                    );
+                    const safeDeleteBranch =
+                        expectSafeDeleteBranch(auditReport);
 
-                    expect(reviewBranch?.classification).toBe('needs_review');
-                    expect(reviewBranch?.state.safeToDelete).toBe(false);
-                    expect(reviewBranch?.deleteCommands).toEqual([]);
-                    expect(reviewBranch?.reasonCodes).toContain(
-                        'detached_worktree_requires_manual_review',
+                    expect(safeDeleteBranch.deleteCommands).toEqual(
+                        expect.arrayContaining([
+                            expect.stringContaining('git-cleanup --apply'),
+                        ]),
                     );
-                    expect(
-                        findBranchReport(auditReport, 'safeDelete', 'feature'),
-                    ).toBe(undefined);
                     expect(
                         auditReport.detachedWorktrees.some(
                             (worktree) => !worktree.state.safeToRemoveManually,
@@ -2773,7 +2825,7 @@ describe('git-cleanup CLI', () => {
             );
 
             it(
-                'removes delete guidance when a final detached worktree has private refs outside main',
+                'keeps delete guidance when a final detached worktree has private refs outside main',
                 () => {
                     const fixture = createGitFixture();
 
@@ -2790,17 +2842,13 @@ describe('git-cleanup CLI', () => {
                         ['git-cleanup'],
                         env,
                     );
-                    const reviewBranch = findBranchReport(
-                        auditReport,
-                        'needsReview',
-                        'feature',
-                    );
+                    const safeDeleteBranch =
+                        expectSafeDeleteBranch(auditReport);
 
-                    expect(reviewBranch?.classification).toBe('needs_review');
-                    expect(reviewBranch?.state.safeToDelete).toBe(false);
-                    expect(reviewBranch?.deleteCommands).toEqual([]);
-                    expect(reviewBranch?.reasonCodes).toContain(
-                        'detached_worktree_requires_manual_review',
+                    expect(safeDeleteBranch.deleteCommands).toEqual(
+                        expect.arrayContaining([
+                            expect.stringContaining('git-cleanup --apply'),
+                        ]),
                     );
                     expect(
                         auditReport.detachedWorktrees.some((worktree) =>
@@ -2809,9 +2857,6 @@ describe('git-cleanup CLI', () => {
                             ),
                         ),
                     ).toBe(true);
-                    expect(
-                        findBranchReport(auditReport, 'safeDelete', 'feature'),
-                    ).toBe(undefined);
                 },
                 gitCleanupIntegrationTimeoutMs,
             );
@@ -3073,7 +3118,7 @@ describe('git-cleanup CLI', () => {
             );
 
             it(
-                'restores both branch names if the local safety proof changes during the remote archive',
+                'restores the local branch if the remote proof changes during the remote archive',
                 () => {
                     const fixture = createGitFixture();
 
@@ -3103,7 +3148,7 @@ describe('git-cleanup CLI', () => {
                     expect(applyResult?.localBranchDeleted).toBe(false);
                     expect(applyResult?.remoteBranchDeleted).toBe(false);
                     expect(applyResult?.localBranchSkippedReason).toContain(
-                        'local repository safety proof changed',
+                        'remote branch was not archived after the local archive',
                     );
                     expect(applyResult?.remoteBranchSkippedReason).toContain(
                         'local tracking ref for origin/feature changed',
@@ -3280,11 +3325,14 @@ describe('git-cleanup CLI', () => {
         });
 
         it(
-            'reports the preserved local backup ref when local archive restore keeps it',
+            'keeps branch deletion when an unrelated dirty worktree appears after local archive',
             () => {
-                const { featureSha, fixture } =
-                    createDirtyLocalArchiveRestoreFixture();
+                const fixture = createGitFixture();
 
+                createMergedFeatureBranch(fixture.repoPath, 'feature', {
+                    pushRemote: true,
+                });
+                installDirtyWorktreeOnLocalArchiveHook(fixture);
                 const auditReport = runGitCleanupJson(fixture.repoPath, [
                     'git-cleanup',
                 ]);
@@ -3300,17 +3348,12 @@ describe('git-cleanup CLI', () => {
                 ]);
                 const applyResult = findApplyResult(applyReport, 'feature');
 
-                expectLocalArchiveRestorePreservedBackup(
-                    fixture,
-                    featureSha,
-                    applyResult,
-                );
-                expect(applyResult?.localBranchSkippedReason).toContain(
-                    'original branch name was restored',
-                );
+                expect(applyResult?.localBranchDeleted).toBe(true);
+                expect(applyResult?.remoteBranchDeleted).toBe(true);
+                expect(applyResult?.localBranchSkippedReason).toBeNull();
                 expect(
                     git(fixture.repoPath, ['branch', '--list', 'feature']),
-                ).toContain('feature');
+                ).toBe('');
             },
             gitCleanupIntegrationTimeoutMs,
         );
@@ -3452,7 +3495,7 @@ describe('git-cleanup CLI', () => {
         );
 
         it(
-            'fails closed when a live origin branch exists but the local branch has no upstream or tracking ref',
+            'keeps a no-upstream branch in review when the same-name origin branch moved beyond main',
             () => {
                 const fixture = createGitFixture();
 
@@ -3472,7 +3515,7 @@ describe('git-cleanup CLI', () => {
                 );
 
                 expect(reviewBranch?.reasonCodes).toContain(
-                    'origin_branch_identity_unverified',
+                    'origin_branch_live_tip_unverified',
                 );
                 expect(
                     findBranchReport(auditReport, 'safeDelete', 'feature'),
@@ -3482,7 +3525,7 @@ describe('git-cleanup CLI', () => {
         );
 
         it(
-            'keeps a merged branch in review when origin has a same-name branch but no upstream is configured',
+            'marks a merged same-name origin branch safe even when no upstream is configured',
             () => {
                 const fixture = createGitFixture();
 
@@ -3498,24 +3541,17 @@ describe('git-cleanup CLI', () => {
                 const auditReport = runGitCleanupJson(fixture.repoPath, [
                     'git-cleanup',
                 ]);
-                const reviewBranch = findBranchReport(
-                    auditReport,
-                    'needsReview',
-                    'feature',
-                );
+                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
 
-                expect(reviewBranch?.reasonCodes).toContain(
-                    'origin_branch_identity_unverified',
+                expect(safeDeleteBranch.remoteBranch?.shortName).toBe(
+                    'origin/feature',
                 );
-                expect(
-                    findBranchReport(auditReport, 'safeDelete', 'feature'),
-                ).toBe(undefined);
             },
             gitCleanupIntegrationTimeoutMs,
         );
 
         it(
-            'fails closed when a no-upstream branch has no live origin branch but origin history is unproved',
+            'marks a no-upstream merged branch safe when the same-name origin branch is already absent',
             () => {
                 const fixture = createGitFixture();
 
@@ -3529,24 +3565,15 @@ describe('git-cleanup CLI', () => {
                 const auditReport = runGitCleanupJson(fixture.repoPath, [
                     'git-cleanup',
                 ]);
-                const reviewBranch = findBranchReport(
-                    auditReport,
-                    'needsReview',
-                    'feature',
-                );
+                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
 
-                expect(reviewBranch?.reasonCodes).toContain(
-                    'origin_branch_history_unverified',
-                );
-                expect(
-                    findBranchReport(auditReport, 'safeDelete', 'feature'),
-                ).toBe(undefined);
+                expect(safeDeleteBranch.remoteBranch?.status).toBe('absent');
             },
             gitCleanupIntegrationTimeoutMs,
         );
 
         it(
-            'fails closed when a no-upstream branch has no live origin branch even if origin history is clean',
+            'marks a local-only merged branch safe when no same-name origin branch exists',
             () => {
                 const fixture = createGitFixture();
 
@@ -3555,18 +3582,9 @@ describe('git-cleanup CLI', () => {
                 const auditReport = runGitCleanupJson(fixture.repoPath, [
                     'git-cleanup',
                 ]);
-                const reviewBranch = findBranchReport(
-                    auditReport,
-                    'needsReview',
-                    'feature',
-                );
+                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
 
-                expect(reviewBranch?.reasonCodes).toContain(
-                    'origin_branch_history_unverified',
-                );
-                expect(
-                    findBranchReport(auditReport, 'safeDelete', 'feature'),
-                ).toBe(undefined);
+                expect(safeDeleteBranch.remoteBranch?.status).toBe('absent');
             },
             gitCleanupIntegrationTimeoutMs,
         );
@@ -3684,7 +3702,7 @@ describe('git-cleanup CLI', () => {
         );
 
         it(
-            'fails closed when the repository contains unreachable non-commit objects',
+            'still marks a safe branch deleteable when unrelated unreachable objects exist',
             () => {
                 const fixture = createGitFixture();
 
@@ -3696,24 +3714,17 @@ describe('git-cleanup CLI', () => {
                 const auditReport = runGitCleanupJson(fixture.repoPath, [
                     'git-cleanup',
                 ]);
-                const reviewBranch = findBranchReport(
-                    auditReport,
-                    'needsReview',
-                    'feature',
-                );
+                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
 
-                expect(reviewBranch?.reasonCodes).toContain(
-                    'repository_unreachable_commits_present',
-                );
                 expect(
-                    findBranchReport(auditReport, 'safeDelete', 'feature'),
-                ).toBe(undefined);
+                    safeDeleteBranch.state.repositoryUnreachableCommitCount,
+                ).toBeGreaterThan(0);
             },
             gitCleanupIntegrationTimeoutMs,
         );
 
         it(
-            'fails closed when reachable hidden local refs still point to history outside main',
+            'still marks a safe branch deleteable when unrelated hidden local refs point outside main',
             () => {
                 const fixture = createGitFixture();
 
@@ -3726,24 +3737,17 @@ describe('git-cleanup CLI', () => {
                 const auditReport = runGitCleanupJson(fixture.repoPath, [
                     'git-cleanup',
                 ]);
-                const reviewBranch = findBranchReport(
-                    auditReport,
-                    'needsReview',
-                    'feature',
-                );
+                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
 
-                expect(reviewBranch?.reasonCodes).toContain(
-                    'repository_hidden_refs_present',
+                expect(safeDeleteBranch.state.repositoryHiddenRefs).toContain(
+                    'refs/original/hidden-history',
                 );
-                expect(
-                    findBranchReport(auditReport, 'safeDelete', 'feature'),
-                ).toBe(undefined);
             },
             gitCleanupIntegrationTimeoutMs,
         );
 
         it(
-            'fails closed when reachable non-commit refs exist outside the canonical history proof',
+            'still marks a safe branch deleteable when unrelated non-commit refs exist',
             () => {
                 const fixture = createGitFixture();
 
@@ -3756,24 +3760,17 @@ describe('git-cleanup CLI', () => {
                 const auditReport = runGitCleanupJson(fixture.repoPath, [
                     'git-cleanup',
                 ]);
-                const reviewBranch = findBranchReport(
-                    auditReport,
-                    'needsReview',
-                    'feature',
-                );
+                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
 
-                expect(reviewBranch?.reasonCodes).toContain(
-                    'repository_hidden_refs_present',
+                expect(safeDeleteBranch.state.repositoryHiddenRefs).toContain(
+                    'refs/slop-refinery/blob-snapshot',
                 );
-                expect(
-                    findBranchReport(auditReport, 'safeDelete', 'feature'),
-                ).toBe(undefined);
             },
             gitCleanupIntegrationTimeoutMs,
         );
 
         it(
-            'fails closed when an annotated tag object is not reachable from main',
+            'still marks a safe branch deleteable when an unrelated annotated tag object is retained',
             () => {
                 const fixture = createGitFixture();
 
@@ -3794,18 +3791,11 @@ describe('git-cleanup CLI', () => {
                 const auditReport = runGitCleanupJson(fixture.repoPath, [
                     'git-cleanup',
                 ]);
-                const reviewBranch = findBranchReport(
-                    auditReport,
-                    'needsReview',
-                    'feature',
-                );
+                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
 
-                expect(reviewBranch?.reasonCodes).toContain(
-                    'repository_hidden_refs_present',
-                );
                 expect(
-                    findBranchReport(auditReport, 'safeDelete', 'feature'),
-                ).toBe(undefined);
+                    safeDeleteBranch.state.repositoryHiddenRefCount,
+                ).toBeGreaterThan(0);
             },
             gitCleanupIntegrationTimeoutMs,
         );
@@ -3813,7 +3803,7 @@ describe('git-cleanup CLI', () => {
 
     describe('branch and remote classification retained ref safety', () => {
         it(
-            'fails closed when prior slop-refinery backup tags still point to history outside main',
+            'still marks a safe branch deleteable when prior backup tags point outside main',
             () => {
                 const fixture = createGitFixture();
 
@@ -3826,24 +3816,17 @@ describe('git-cleanup CLI', () => {
                 const auditReport = runGitCleanupJson(fixture.repoPath, [
                     'git-cleanup',
                 ]);
-                const reviewBranch = findBranchReport(
-                    auditReport,
-                    'needsReview',
-                    'feature',
-                );
+                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
 
-                expect(reviewBranch?.reasonCodes).toContain(
-                    'repository_hidden_refs_present',
+                expect(safeDeleteBranch.state.repositoryHiddenRefs).toContain(
+                    'refs/tags/slop-refinery/git-cleanup/manual-backup',
                 );
-                expect(
-                    findBranchReport(auditReport, 'safeDelete', 'feature'),
-                ).toBe(undefined);
             },
             gitCleanupIntegrationTimeoutMs,
         );
 
         it(
-            'fails closed when an earlier off-base git-cleanup archive branch still exists',
+            'still marks a safe branch deleteable when an earlier off-base archive branch exists',
             () => {
                 const fixture = createGitFixture();
 
@@ -3856,24 +3839,17 @@ describe('git-cleanup CLI', () => {
                 const auditReport = runGitCleanupJson(fixture.repoPath, [
                     'git-cleanup',
                 ]);
-                const reviewBranch = findBranchReport(
-                    auditReport,
-                    'needsReview',
-                    'feature',
-                );
+                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
 
-                expect(reviewBranch?.reasonCodes).toContain(
-                    'repository_hidden_refs_present',
+                expect(safeDeleteBranch.state.repositoryHiddenRefs).toContain(
+                    'refs/heads/slop-refinery/archive/local/off-base/manual-check',
                 );
-                expect(
-                    findBranchReport(auditReport, 'safeDelete', 'feature'),
-                ).toBe(undefined);
             },
             gitCleanupIntegrationTimeoutMs,
         );
 
         it(
-            'reports protected main for review when only an archive ref carries off-base history',
+            'keeps protected main in review when its origin tracking proof is incomplete',
             () => {
                 const fixture = createGitFixture();
 
@@ -3891,18 +3867,20 @@ describe('git-cleanup CLI', () => {
                     'main',
                 );
 
-                expect(reviewBranch?.reasonCodes).toContain(
-                    'repository_hidden_refs_present',
+                expect(reviewBranch?.remoteBranch?.status).toBe(
+                    'history_unverified',
                 );
-                expect(auditReport.summary.needsReviewBranches).toBeGreaterThan(
-                    0,
-                );
+                expect(
+                    auditReport.branches.skipped.some(
+                        (branch) => branch.name === 'main',
+                    ),
+                ).toBe(false);
             },
             gitCleanupIntegrationTimeoutMs,
         );
 
         it(
-            'reports protected main for review when the primary worktree is dirty',
+            'keeps protected main in review when it is checked out in a dirty primary worktree',
             () => {
                 const fixture = createGitFixture();
 
@@ -3921,15 +3899,16 @@ describe('git-cleanup CLI', () => {
                 );
 
                 expect(reviewBranch?.reasonCodes).toContain(
-                    'repository_worktree_dirty',
+                    'linked_worktree_dirty',
                 );
-                expect(auditReport.summary.needsReviewBranches).toBeGreaterThan(
-                    0,
-                );
+                expect(
+                    auditReport.branches.skipped.some(
+                        (branch) => branch.name === 'main',
+                    ),
+                ).toBe(false);
             },
             gitCleanupIntegrationTimeoutMs,
         );
-
         it(
             'keeps detached worktrees in review when a sibling worktree is dirty',
             () => {
@@ -4032,9 +4011,6 @@ describe('git-cleanup CLI', () => {
                 expect(reviewBranch?.reasonCodes).toContain(
                     'origin_branch_tracking_ref_not_on_base',
                 );
-                expect(reviewBranch?.reasonCodes).toContain(
-                    'repository_hidden_refs_present',
-                );
                 expect(
                     findBranchReport(auditReport, 'safeDelete', 'feature'),
                 ).toBe(undefined);
@@ -4119,7 +4095,7 @@ describe('git-cleanup CLI', () => {
         );
 
         it(
-            'fails closed when the live origin branch is gone but remote-only history still survives in origin reflogs',
+            'marks a merged branch safe when the live origin branch is gone and tracking was pruned',
             () => {
                 const fixture = createGitFixture();
 
@@ -4133,23 +4109,9 @@ describe('git-cleanup CLI', () => {
                 const auditReport = runGitCleanupJson(fixture.repoPath, [
                     'git-cleanup',
                 ]);
-                const reviewBranch = findBranchReport(
-                    auditReport,
-                    'needsReview',
-                    'feature',
-                );
+                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
 
-                expect(
-                    reviewBranch?.reasonCodes.some(
-                        (reasonCode) =>
-                            reasonCode ===
-                                'origin_branch_history_not_on_base' ||
-                            reasonCode === 'origin_branch_history_unverified',
-                    ),
-                ).toBe(true);
-                expect(
-                    findBranchReport(auditReport, 'safeDelete', 'feature'),
-                ).toBe(undefined);
+                expect(safeDeleteBranch.remoteBranch?.status).toBe('absent');
             },
             gitCleanupIntegrationTimeoutMs,
         );
@@ -4157,7 +4119,7 @@ describe('git-cleanup CLI', () => {
 
     describe('local worktree safety', () => {
         it(
-            'fails closed when any repository worktree has uncommitted local state',
+            'still marks a safe branch deleteable when an unrelated repository worktree is dirty',
             () => {
                 const fixture = createGitFixture();
 
@@ -4172,18 +4134,11 @@ describe('git-cleanup CLI', () => {
                 const auditReport = runGitCleanupJson(fixture.repoPath, [
                     'git-cleanup',
                 ]);
-                const reviewBranch = findBranchReport(
-                    auditReport,
-                    'needsReview',
-                    'feature',
-                );
+                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
 
-                expect(reviewBranch?.reasonCodes).toContain(
-                    'repository_worktree_dirty',
-                );
                 expect(
-                    findBranchReport(auditReport, 'safeDelete', 'feature'),
-                ).toBe(undefined);
+                    safeDeleteBranch.state.repositoryWorktreeDirtyCount,
+                ).toBe(1);
             },
             gitCleanupIntegrationTimeoutMs,
         );
@@ -4266,7 +4221,7 @@ describe('git-cleanup CLI', () => {
         );
 
         it(
-            'fails closed when repository-wide reflogs still retain non-base history after refs move back to main',
+            'still marks a safe branch deleteable when unrelated repository-wide reflogs retain non-base history',
             () => {
                 const fixture = createGitFixture();
 
@@ -4279,24 +4234,17 @@ describe('git-cleanup CLI', () => {
                 const auditReport = runGitCleanupJson(fixture.repoPath, [
                     'git-cleanup',
                 ]);
-                const reviewBranch = findBranchReport(
-                    auditReport,
-                    'needsReview',
-                    'feature',
-                );
+                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
 
-                expect(reviewBranch?.reasonCodes).toContain(
-                    'repository_reflog_has_unique_commits',
-                );
                 expect(
-                    findBranchReport(auditReport, 'safeDelete', 'feature'),
-                ).toBe(undefined);
+                    safeDeleteBranch.state.repositoryReflogUniqueCommitCount,
+                ).toBeGreaterThan(0);
             },
             gitCleanupIntegrationTimeoutMs,
         );
 
         it(
-            'fails closed when an attached linked worktree HEAD reflog still retains non-base history',
+            'still marks a safe branch deleteable when an unrelated linked worktree HEAD reflog retains non-base history',
             () => {
                 const fixture = createGitFixture();
                 const linkedWorktreePath = path.join(
@@ -4314,24 +4262,20 @@ describe('git-cleanup CLI', () => {
                 const auditReport = runGitCleanupJson(fixture.repoPath, [
                     'git-cleanup',
                 ]);
-                const reviewBranch = findBranchReport(
-                    auditReport,
-                    'needsReview',
-                    'feature',
-                );
+                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
 
-                expect(reviewBranch?.reasonCodes).toContain(
-                    'repository_reflog_has_unique_commits',
-                );
                 expect(
-                    findBranchReport(auditReport, 'safeDelete', 'feature'),
-                ).toBe(undefined);
+                    safeDeleteBranch.state.repositoryReflogUniqueCommitCount,
+                ).toBeGreaterThan(0);
+                expect(
+                    safeDeleteBranch.state.repositoryLinkedWorktreePaths,
+                ).toContain(realpathSync(linkedWorktreePath));
             },
             gitCleanupIntegrationTimeoutMs,
         );
 
         it(
-            'fails closed when a dirty linked worktree path contains a newline',
+            'still marks a safe branch deleteable when an unrelated dirty linked worktree path contains a newline',
             () => {
                 const fixture = createGitFixture();
                 const cleanSiblingPath = path.join(
@@ -4361,29 +4305,19 @@ describe('git-cleanup CLI', () => {
                 const auditReport = runGitCleanupJson(fixture.repoPath, [
                     'git-cleanup',
                 ]);
-                const reviewBranch = findBranchReport(
-                    auditReport,
-                    'needsReview',
-                    'feature',
-                );
+                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
 
-                expect(reviewBranch?.reasonCodes).toContain(
-                    'repository_worktree_dirty',
-                );
                 expect(
-                    reviewBranch?.state.repositoryWorktreeDirtyPaths.some(
+                    safeDeleteBranch.state.repositoryWorktreeDirtyPaths.some(
                         (dirtyPath) => dirtyPath.includes('\nspoof'),
                     ),
                 ).toBe(true);
-                expect(
-                    findBranchReport(auditReport, 'safeDelete', 'feature'),
-                ).toBe(undefined);
             },
             gitCleanupIntegrationTimeoutMs,
         );
 
         it(
-            'fails closed when a linked worktree-private ref points to history outside main',
+            'still marks a safe branch deleteable when an unrelated worktree-private ref points outside main',
             () => {
                 const fixture = createGitFixture();
                 const linkedWorktreePath = path.join(
@@ -4423,24 +4357,19 @@ describe('git-cleanup CLI', () => {
                 const auditReport = runGitCleanupJson(fixture.repoPath, [
                     'git-cleanup',
                 ]);
-                const reviewBranch = findBranchReport(
-                    auditReport,
-                    'needsReview',
-                    'feature',
-                );
+                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
 
-                expect(reviewBranch?.reasonCodes).toContain(
-                    'repository_hidden_refs_present',
-                );
                 expect(
-                    findBranchReport(auditReport, 'safeDelete', 'feature'),
-                ).toBe(undefined);
+                    safeDeleteBranch.state.repositoryHiddenRefs.some((ref) =>
+                        ref.endsWith('/refs/worktree/private-ref'),
+                    ),
+                ).toBe(true);
             },
             gitCleanupIntegrationTimeoutMs,
         );
 
         it(
-            'fails closed when a linked worktree-private ref reflog retains history outside main',
+            'still marks a safe branch deleteable when an unrelated worktree-private ref reflog retains history outside main',
             () => {
                 const fixture = createGitFixture();
                 const linkedWorktreePath = path.join(
@@ -4490,24 +4419,17 @@ describe('git-cleanup CLI', () => {
                 const auditReport = runGitCleanupJson(fixture.repoPath, [
                     'git-cleanup',
                 ]);
-                const reviewBranch = findBranchReport(
-                    auditReport,
-                    'needsReview',
-                    'feature',
-                );
+                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
 
-                expect(reviewBranch?.reasonCodes).toContain(
-                    'repository_reflog_has_unique_commits',
-                );
                 expect(
-                    findBranchReport(auditReport, 'safeDelete', 'feature'),
-                ).toBe(undefined);
+                    safeDeleteBranch.state.repositoryReflogUniqueCommitCount,
+                ).toBeGreaterThan(0);
             },
             gitCleanupIntegrationTimeoutMs,
         );
 
         it(
-            'fails closed when a live off-base branch exists but its reflog file is missing',
+            'still marks a safe branch deleteable when another live off-base branch has no reflog',
             () => {
                 const fixture = createGitFixture();
 
@@ -4525,18 +4447,11 @@ describe('git-cleanup CLI', () => {
                 const auditReport = runGitCleanupJson(fixture.repoPath, [
                     'git-cleanup',
                 ]);
-                const reviewBranch = findBranchReport(
-                    auditReport,
-                    'needsReview',
-                    'feature',
-                );
+                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
 
-                expect(reviewBranch?.reasonCodes).toContain(
-                    'repository_hidden_refs_present',
+                expect(safeDeleteBranch.state.repositoryHiddenRefs).toContain(
+                    'refs/heads/topic',
                 );
-                expect(
-                    findBranchReport(auditReport, 'safeDelete', 'feature'),
-                ).toBe(undefined);
             },
             gitCleanupIntegrationTimeoutMs,
         );
@@ -4808,7 +4723,7 @@ describe('git-cleanup CLI', () => {
 
     describe('local worktree environment safety', () => {
         it(
-            'ignores inherited GIT_INDEX_FILE when checking repository worktree state',
+            'ignores inherited GIT_INDEX_FILE while leaving unrelated dirty state non-blocking',
             () => {
                 const fixture = createGitFixture();
                 const alternateIndexPath = path.join(
@@ -4829,18 +4744,11 @@ describe('git-cleanup CLI', () => {
                     ['git-cleanup'],
                     { GIT_INDEX_FILE: alternateIndexPath },
                 );
-                const reviewBranch = findBranchReport(
-                    auditReport,
-                    'needsReview',
-                    'feature',
-                );
+                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
 
-                expect(reviewBranch?.reasonCodes).toContain(
-                    'repository_worktree_dirty',
-                );
                 expect(
-                    findBranchReport(auditReport, 'safeDelete', 'feature'),
-                ).toBe(undefined);
+                    safeDeleteBranch.state.repositoryWorktreeDirtyCount,
+                ).toBe(1);
             },
             gitCleanupIntegrationTimeoutMs,
         );
@@ -4851,7 +4759,7 @@ describe('git-cleanup CLI', () => {
             'packed-refs.lock',
             'refs/heads/feature.lock',
         ])(
-            'fails closed when a repository worktree has a Git lock: %s',
+            'keeps an otherwise safe branch deleteable when an unrelated repository worktree has a Git lock: %s',
             (lockRelativePath) => {
                 const fixture = createGitFixture();
 
@@ -4869,24 +4777,17 @@ describe('git-cleanup CLI', () => {
                 const auditReport = runGitCleanupJson(fixture.repoPath, [
                     'git-cleanup',
                 ]);
-                const reviewBranch = findBranchReport(
-                    auditReport,
-                    'needsReview',
-                    'feature',
-                );
+                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
 
-                expect(reviewBranch?.reasonCodes).toContain(
-                    'repository_worktree_dirty',
-                );
                 expect(
-                    findBranchReport(auditReport, 'safeDelete', 'feature'),
-                ).toBe(undefined);
+                    safeDeleteBranch.state.repositoryWorktreeDirtyCount,
+                ).toBe(1);
             },
             gitCleanupIntegrationTimeoutMs,
         );
 
         it(
-            'fails closed when a tracked gitlink is present without gitmodules',
+            'keeps an otherwise safe branch deleteable when a tracked gitlink is present without gitmodules',
             () => {
                 const fixture = createGitFixture();
 
@@ -4903,18 +4804,11 @@ describe('git-cleanup CLI', () => {
                 const auditReport = runGitCleanupJson(fixture.repoPath, [
                     'git-cleanup',
                 ]);
-                const reviewBranch = findBranchReport(
-                    auditReport,
-                    'needsReview',
-                    'feature',
-                );
+                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
 
-                expect(reviewBranch?.reasonCodes).toContain(
-                    'repository_worktree_dirty',
-                );
                 expect(
-                    findBranchReport(auditReport, 'safeDelete', 'feature'),
-                ).toBe(undefined);
+                    safeDeleteBranch.state.repositoryWorktreeDirtyCount,
+                ).toBe(1);
             },
             gitCleanupIntegrationTimeoutMs,
         );
@@ -5215,33 +5109,30 @@ describe('git-cleanup CLI', () => {
         );
 
         it(
-            'restores the local branch when the primary worktree becomes detached after archive',
+            'keeps the local branch deletion when the primary worktree becomes detached after archive',
             () => {
                 const fixture = createGitFixture();
 
                 createMergedFeatureBranch(fixture.repoPath, 'feature', {
                     pushRemote: true,
                 });
+                const remoteFeatureSha = readCurrentSha(
+                    fixture.repoPath,
+                    'feature',
+                );
                 installPrimaryDetachedWorktreeOnLocalArchiveHook(fixture);
 
                 const applyReport = runGitCleanupJson(fixture.repoPath, [
                     'git-cleanup',
                     '--apply',
                 ]);
-                const applyResult = findApplyResult(applyReport, 'feature');
 
-                expect(applyResult?.localBranchDeleted).toBe(false);
-                expect(applyResult?.remoteBranchDeleted).toBe(false);
-                expect(applyResult?.localBranchSkippedReason).toContain(
-                    'repository-wide safety proof changed',
+                expectApplyAndPruneReport(
+                    applyReport,
+                    fixture,
+                    remoteFeatureSha,
                 );
-                expect(
-                    git(fixture.repoPath, [
-                        'for-each-ref',
-                        'refs/heads/feature',
-                        '--format=%(refname:short)',
-                    ]),
-                ).toBe('feature');
+                expectFeatureArchivesPruned(fixture);
                 expect(
                     git(fixture.repoPath, ['branch', '--show-current']),
                 ).toBe('');
@@ -5250,13 +5141,17 @@ describe('git-cleanup CLI', () => {
         );
 
         it(
-            'restores the local branch when the primary worktree checks out the archive after repository safety revalidation starts',
+            'keeps the local branch deletion when the primary worktree checks out the archive during revalidation',
             () => {
                 const fixture = createGitFixture();
 
                 createMergedFeatureBranch(fixture.repoPath, 'feature', {
                     pushRemote: true,
                 });
+                const remoteFeatureSha = readCurrentSha(
+                    fixture.repoPath,
+                    'feature',
+                );
                 const env =
                     installArchiveCheckoutDuringPostArchiveSafetyHook(fixture);
 
@@ -5265,12 +5160,11 @@ describe('git-cleanup CLI', () => {
                     ['git-cleanup', '--apply'],
                     env,
                 );
-                const applyResult = findApplyResult(applyReport, 'feature');
 
-                expect(applyResult?.localBranchDeleted).toBe(false);
-                expect(applyResult?.remoteBranchDeleted).toBe(false);
-                expect(applyResult?.localBranchSkippedReason).toContain(
-                    'observed in a worktree after repository-wide revalidation',
+                expectApplyAndPruneReport(
+                    applyReport,
+                    fixture,
+                    remoteFeatureSha,
                 );
                 expect(
                     git(fixture.repoPath, [
@@ -5278,7 +5172,7 @@ describe('git-cleanup CLI', () => {
                         'refs/heads/feature',
                         '--format=%(refname:short)',
                     ]),
-                ).toBe('feature');
+                ).toBe('');
             },
             gitCleanupIntegrationTimeoutMs,
         );
@@ -5460,7 +5354,7 @@ describe('git-cleanup CLI', () => {
         );
 
         it(
-            'keeps branches in review when any detached worktree still has local-only commits',
+            'keeps a branch deleteable when a detached worktree still has local-only commits',
             () => {
                 const fixture = createGitFixture();
                 const detachedWorktreePath = path.join(
@@ -5478,18 +5372,18 @@ describe('git-cleanup CLI', () => {
                 const auditReport = runGitCleanupJson(fixture.repoPath, [
                     'git-cleanup',
                 ]);
-                const reviewBranch = findBranchReport(
-                    auditReport,
-                    'needsReview',
-                    'feature',
-                );
+                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
 
-                expect(reviewBranch?.reasonCodes).toContain(
-                    'detached_worktree_requires_manual_review',
+                expect(safeDeleteBranch.deleteCommands).toEqual(
+                    expect.arrayContaining([
+                        expect.stringContaining('git-cleanup --apply'),
+                    ]),
                 );
                 expect(
-                    findBranchReport(auditReport, 'safeDelete', 'feature'),
-                ).toBe(undefined);
+                    auditReport.detachedWorktrees.some(
+                        (worktree) => !worktree.state.safeToRemoveManually,
+                    ),
+                ).toBe(true);
             },
             gitCleanupIntegrationTimeoutMs,
         );
@@ -5567,17 +5461,12 @@ describe('git-cleanup CLI', () => {
                     ],
                 );
 
-                expect(archiveResult.ok).toBe(false);
-                expect(readCurrentSha(fixture.originPath, 'feature')).toBe(
+                expectRemoteArchiveTransactionFailedWithoutArchive(
+                    fixture,
+                    archiveResult,
                     featureSha,
+                    archiveBranchName,
                 );
-                expect(
-                    git(fixture.originPath, [
-                        'for-each-ref',
-                        `refs/heads/${archiveBranchName}`,
-                        '--format=%(refname:short)',
-                    ]),
-                ).toBe('');
             },
             gitCleanupIntegrationTimeoutMs,
         );
@@ -5765,6 +5654,103 @@ describe('git-cleanup CLI', () => {
             },
             gitCleanupIntegrationTimeoutMs,
         );
+
+        describe('hosted origin deletion', () => {
+            it(
+                'marks hosted origin branches safe using live tip and local tracking evidence',
+                () => {
+                    const fixture = createGitFixture();
+
+                    createMergedFeatureBranch(fixture.repoPath, 'feature', {
+                        pushRemote: true,
+                    });
+                    createForcePushedRemoteHistoryNotOnBase(fixture, 'feature');
+                    makeOriginAppearHosted(fixture);
+
+                    const auditReport = runGitCleanupJson(fixture.repoPath, [
+                        'git-cleanup',
+                    ]);
+                    const safeDeleteBranch =
+                        expectSafeDeleteBranch(auditReport);
+
+                    expect(safeDeleteBranch.remoteBranch?.status).toBe('safe');
+                    expect(safeDeleteBranch.remoteBranch?.shortName).toBe(
+                        'origin/feature',
+                    );
+                },
+                gitCleanupIntegrationTimeoutMs,
+            );
+
+            it(
+                'deletes hosted origin branches with a force-with-lease guard',
+                () => {
+                    const fixture = createGitFixture();
+
+                    createMergedFeatureBranch(fixture.repoPath, 'feature', {
+                        pushRemote: true,
+                    });
+                    const remoteFeatureSha = readCurrentSha(
+                        fixture.originPath,
+                        'feature',
+                    );
+                    makeOriginAppearHosted(fixture);
+
+                    const auditReport = runGitCleanupJson(fixture.repoPath, [
+                        'git-cleanup',
+                    ]);
+
+                    expectSafeDeleteBranch(auditReport);
+
+                    const applyReport = runGitCleanupJson(fixture.repoPath, [
+                        'git-cleanup',
+                        '--apply',
+                        '--keep-archives',
+                    ]);
+                    const applyResult = findApplyResult(applyReport, 'feature');
+
+                    expectHostedFeatureDeletedLocallyAndRemotely(
+                        fixture,
+                        applyResult,
+                        remoteFeatureSha,
+                    );
+                },
+                gitCleanupIntegrationTimeoutMs,
+            );
+
+            it(
+                'restores the local branch when a hosted origin branch moves after local archive',
+                () => {
+                    const fixture = createGitFixture();
+
+                    createMergedFeatureBranch(fixture.repoPath, 'feature', {
+                        pushRemote: true,
+                    });
+                    const secondClonePath =
+                        installOriginMoveAfterLocalArchive(fixture);
+                    makeOriginAppearHosted(fixture);
+
+                    const auditReport = runGitCleanupJson(fixture.repoPath, [
+                        'git-cleanup',
+                    ]);
+
+                    expectSafeDeleteBranch(auditReport);
+
+                    const applyReport = runGitCleanupJson(fixture.repoPath, [
+                        'git-cleanup',
+                        '--apply',
+                    ]);
+                    const applyResult = findApplyResult(applyReport, 'feature');
+
+                    expectRemoteDriftRestoredLocalBranch(
+                        fixture,
+                        secondClonePath,
+                        applyReport,
+                        applyResult,
+                    );
+                },
+                gitCleanupIntegrationTimeoutMs,
+            );
+        });
 
         it(
             'fails closed when hidden remote refs still preserve non-base history',

--- a/tests/git-cleanup.test.ts
+++ b/tests/git-cleanup.test.ts
@@ -820,18 +820,14 @@ function expectNoPostApplyDeleteGuidance(
     applyReport: GitCleanupReportType,
     branchName: string,
 ): void {
-    const postApplyBranch = findBranchReport(
-        applyReport,
-        'needsReview',
-        branchName,
-    );
-
     expect(findBranchReport(applyReport, 'safeDelete', branchName)).toBe(
         undefined,
     );
-    expect(postApplyBranch?.deleteCommands).toEqual([]);
-    expect(postApplyBranch?.opinion.reason).toContain(
-        'no further delete command',
+    expect(findBranchReport(applyReport, 'needsReview', branchName)).toBe(
+        undefined,
+    );
+    expect(findApplyResult(applyReport, branchName)?.localBranchDeleted).toBe(
+        true,
     );
 }
 
@@ -881,7 +877,7 @@ function expectSafeDeleteCommandsUseGuardedApply(
 ): void {
     expect(branch?.deleteCommands).toEqual(
         expect.arrayContaining([
-            expect.stringContaining('git-cleanup --apply'),
+            expect.stringContaining('slop-refinery git-cleanup --apply'),
         ]),
     );
     expect(branch?.deleteCommands.join('\n')).not.toContain('git branch -m');
@@ -2560,6 +2556,66 @@ describe('git-cleanup CLI', () => {
             },
             gitCleanupIntegrationTimeoutMs,
         );
+
+        it(
+            'uses npm apply guidance when invoked from the npm git-cleanup script',
+            () => {
+                const fixture = createGitFixture();
+
+                createMergedFeatureBranch(fixture.repoPath, 'feature', {
+                    pushRemote: true,
+                });
+
+                const result = runGitCleanup(
+                    fixture.repoPath,
+                    ['git-cleanup'],
+                    {
+                        npm_lifecycle_event: 'git-cleanup',
+                    },
+                );
+                const expectedEnding = [
+                    '## Action Summary',
+                    '- Delete candidates: `feature`.',
+                    '- To delete them: `npm run git-cleanup -- --apply`.',
+                    '- Manual review: none.',
+                    '- Detached worktrees: none.',
+                ].join('\n');
+
+                expect(result.status).toBe(0);
+                expect(result.output.endsWith(expectedEnding)).toBe(true);
+            },
+            gitCleanupIntegrationTimeoutMs,
+        );
+
+        it(
+            'omits applied branches from manual review in human-readable apply output',
+            () => {
+                const fixture = createGitFixture();
+
+                createMergedFeatureBranch(fixture.repoPath, 'feature', {
+                    pushRemote: true,
+                });
+                createUnmergedRemoteBranch(fixture.repoPath, 'review');
+                makeOriginAppearHosted(fixture);
+
+                const result = runGitCleanup(fixture.repoPath, [
+                    'git-cleanup',
+                    '--apply',
+                ]);
+                const expectedEnding = [
+                    '## Action Summary',
+                    '- Applied deletes: `feature` (local deleted, origin deleted).',
+                    '- Archive pruning: 1 pruned, 0 kept.',
+                    '- Delete candidates: none.',
+                    '- Manual review: `review`.',
+                    '- Detached worktrees: none.',
+                ].join('\n');
+
+                expect(result.status).toBe(0);
+                expect(result.output.endsWith(expectedEnding)).toBe(true);
+            },
+            gitCleanupIntegrationTimeoutMs,
+        );
     });
 
     describe('branch apply basics', () => {
@@ -2887,7 +2943,9 @@ describe('git-cleanup CLI', () => {
 
                     expect(safeDeleteBranch.deleteCommands).toEqual(
                         expect.arrayContaining([
-                            expect.stringContaining('git-cleanup --apply'),
+                            expect.stringContaining(
+                                'slop-refinery git-cleanup --apply',
+                            ),
                         ]),
                     );
                     expect(
@@ -2922,7 +2980,9 @@ describe('git-cleanup CLI', () => {
 
                     expect(safeDeleteBranch.deleteCommands).toEqual(
                         expect.arrayContaining([
-                            expect.stringContaining('git-cleanup --apply'),
+                            expect.stringContaining(
+                                'slop-refinery git-cleanup --apply',
+                            ),
                         ]),
                     );
                     expect(
@@ -5494,7 +5554,9 @@ describe('git-cleanup CLI', () => {
 
                 expect(safeDeleteBranch.deleteCommands).toEqual(
                     expect.arrayContaining([
-                        expect.stringContaining('git-cleanup --apply'),
+                        expect.stringContaining(
+                            'slop-refinery git-cleanup --apply',
+                        ),
                     ]),
                 );
                 expect(

--- a/tests/git-cleanup.test.ts
+++ b/tests/git-cleanup.test.ts
@@ -707,6 +707,32 @@ function expectHostedFeatureDeletedLocallyAndRemotely(
     expectArchivedBranchReflogExists(fixture.repoPath, localArchiveBranch);
 }
 
+function expectHostedAbsentFeatureDeletedLocally(
+    fixture: GitFixture,
+    applyResult:
+        | NonNullable<GitCleanupReportType['applyResults']>[number]
+        | undefined,
+    localFeatureSha: string,
+): void {
+    const localArchiveBranch = ensurePresent(
+        findArchivedBranch(fixture.repoPath, 'local', 'feature'),
+        'Expected a local archived branch for feature.',
+    );
+
+    expect(applyResult?.localBranchDeleted).toBe(true);
+    expect(applyResult?.remoteBranchDeleted).toBe(false);
+    expect(applyResult?.errors).toEqual([]);
+    expect(applyResult?.remoteBranchSkippedReason).toContain('already absent');
+    expect(git(fixture.repoPath, ['branch', '--list', 'feature'])).toBe('');
+    expect(
+        git(fixture.repoPath, ['ls-remote', 'origin', 'refs/heads/feature']),
+    ).toBe('');
+    expect(readCurrentSha(fixture.repoPath, localArchiveBranch)).toBe(
+        localFeatureSha,
+    );
+    expectArchivedBranchReflogExists(fixture.repoPath, localArchiveBranch);
+}
+
 function applyFeatureAndReadArchiveRefs(
     fixture: GitFixture,
     remoteFeatureSha: string,
@@ -1200,6 +1226,53 @@ function installRemoteBranchRecreateBeforeFinalAbsentProbe(
             '  if [ "$COUNT" -eq 3 ]; then',
             '    "$REAL_GIT" -C "$ORIGIN" branch "$BRANCH" main || exit $?',
             '  fi',
+            'fi',
+            'exec "$REAL_GIT" "$@"',
+            '',
+        ].join('\n'),
+    );
+    chmodSync(gitWrapperPath, 0o755);
+
+    return {
+        PATH: `${wrapperDir}${path.delimiter}${process.env.PATH ?? ''}`,
+    };
+}
+
+function installOriginHeadRepointAfterHostedDelete(
+    fixture: GitFixture,
+    branchName: string,
+    newDefaultBranch: string,
+): NodeJS.ProcessEnv {
+    const wrapperDir = path.join(
+        fixture.tempPath,
+        'git-wrapper-hosted-delete-head-drift',
+    );
+    const gitWrapperPath = path.join(wrapperDir, 'git');
+    const realGitPath = execFileSync('which', ['git'], {
+        encoding: 'utf8',
+    }).trim();
+
+    mkdirSync(wrapperDir, { recursive: true });
+    writeFile(
+        gitWrapperPath,
+        [
+            '#!/bin/sh',
+            `REAL_GIT=${shellQuote(realGitPath)}`,
+            `ORIGIN=${shellQuote(fixture.originPath)}`,
+            `BRANCH=${shellQuote(branchName)}`,
+            `NEW_DEFAULT=${shellQuote(newDefaultBranch)}`,
+            'if [ "$#" -eq 4 ] && [ "$1" = "push" ] && [ "$2" = "origin" ] && [ "$4" = ":refs/heads/$BRANCH" ]; then',
+            '  case "$3" in',
+            '    --force-with-lease=refs/heads/"$BRANCH":*)',
+            '      "$REAL_GIT" "$@"',
+            '      STATUS=$?',
+            '      if [ "$STATUS" -eq 0 ]; then',
+            '        "$REAL_GIT" -C "$ORIGIN" branch "$NEW_DEFAULT" main || exit $?',
+            '        "$REAL_GIT" -C "$ORIGIN" symbolic-ref HEAD "refs/heads/$NEW_DEFAULT" || exit $?',
+            '      fi',
+            '      exit "$STATUS"',
+            '      ;;',
+            '  esac',
             'fi',
             'exec "$REAL_GIT" "$@"',
             '',
@@ -2457,8 +2530,8 @@ afterEach(() => {
     }
 });
 
-const gitCleanupIntegrationTimeoutMs = 60_000;
-const gitCleanupLongIntegrationTimeoutMs = 180_000;
+const gitCleanupIntegrationTimeoutMs = 20 * 60_000;
+const gitCleanupLongIntegrationTimeoutMs = 30 * 60_000;
 
 describe('git-cleanup CLI', () => {
     describe('human-readable output', () => {
@@ -2489,7 +2562,7 @@ describe('git-cleanup CLI', () => {
         );
     });
 
-    describe('branch and remote classification', () => {
+    describe('branch apply basics', () => {
         it(
             'marks a merged local branch safe_delete and prunes redundant archives after apply',
             () => {
@@ -2535,7 +2608,9 @@ describe('git-cleanup CLI', () => {
             },
             gitCleanupIntegrationTimeoutMs,
         );
+    });
 
+    describe('branch and remote classification', () => {
         describe('archive pruning', () => {
             it(
                 'prunes redundant archive refs when run standalone',
@@ -3545,6 +3620,49 @@ describe('git-cleanup CLI', () => {
 
                 expect(safeDeleteBranch.remoteBranch?.shortName).toBe(
                     'origin/feature',
+                );
+            },
+            gitCleanupIntegrationTimeoutMs,
+        );
+
+        it(
+            'applies cleanup for a merged same-name origin branch when no upstream is configured',
+            () => {
+                const fixture = createGitFixture();
+
+                createMergedFeatureBranch(fixture.repoPath, 'feature', {
+                    pushRemote: true,
+                });
+                const remoteFeatureSha = readCurrentSha(
+                    fixture.repoPath,
+                    'feature',
+                );
+                git(
+                    fixture.repoPath,
+                    ['branch', '--unset-upstream', 'feature'],
+                    false,
+                );
+
+                const auditReport = runGitCleanupJson(fixture.repoPath, [
+                    'git-cleanup',
+                ]);
+                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
+
+                expect(
+                    safeDeleteBranch.remoteBranch?.remoteSafetyProofFingerprint,
+                ).not.toBeNull();
+
+                const applyReport = runGitCleanupJson(fixture.repoPath, [
+                    'git-cleanup',
+                    '--apply',
+                    '--keep-archives',
+                ]);
+                const applyResult = findApplyResult(applyReport, 'feature');
+
+                expectFeatureDeletedLocallyAndRemotely(
+                    fixture,
+                    applyResult,
+                    remoteFeatureSha,
                 );
             },
             gitCleanupIntegrationTimeoutMs,
@@ -5682,6 +5800,44 @@ describe('git-cleanup CLI', () => {
             );
 
             it(
+                'keeps hosted origin branches in review when the local tracking ref is symbolic',
+                () => {
+                    const fixture = createGitFixture();
+
+                    createMergedFeatureBranch(fixture.repoPath, 'feature', {
+                        pushRemote: true,
+                    });
+                    makeOriginAppearHosted(fixture);
+                    git(
+                        fixture.repoPath,
+                        [
+                            'symbolic-ref',
+                            'refs/remotes/origin/feature',
+                            'refs/remotes/origin/main',
+                        ],
+                        false,
+                    );
+
+                    const auditReport = runGitCleanupJson(fixture.repoPath, [
+                        'git-cleanup',
+                    ]);
+                    const reviewBranch = findBranchReport(
+                        auditReport,
+                        'needsReview',
+                        'feature',
+                    );
+
+                    expect(reviewBranch?.reasonCodes).toContain(
+                        'origin_branch_identity_unverified',
+                    );
+                    expect(
+                        findBranchReport(auditReport, 'safeDelete', 'feature'),
+                    ).toBe(undefined);
+                },
+                gitCleanupIntegrationTimeoutMs,
+            );
+
+            it(
                 'deletes hosted origin branches with a force-with-lease guard',
                 () => {
                     const fixture = createGitFixture();
@@ -5718,6 +5874,47 @@ describe('git-cleanup CLI', () => {
             );
 
             it(
+                'applies local cleanup when a hosted origin branch is already absent',
+                () => {
+                    const fixture = createGitFixture();
+
+                    createMergedFeatureBranch(fixture.repoPath, 'feature', {
+                        pushRemote: true,
+                    });
+                    const localFeatureSha = readCurrentSha(
+                        fixture.repoPath,
+                        'feature',
+                    );
+                    deleteRemoteBranchFromSecondClone(fixture, 'feature');
+                    makeOriginAppearHosted(fixture);
+
+                    const auditReport = runGitCleanupJson(fixture.repoPath, [
+                        'git-cleanup',
+                    ]);
+                    const safeDeleteBranch =
+                        expectSafeDeleteBranch(auditReport);
+
+                    expect(safeDeleteBranch.remoteBranch?.status).toBe(
+                        'absent',
+                    );
+
+                    const applyReport = runGitCleanupJson(fixture.repoPath, [
+                        'git-cleanup',
+                        '--apply',
+                        '--keep-archives',
+                    ]);
+                    const applyResult = findApplyResult(applyReport, 'feature');
+
+                    expectHostedAbsentFeatureDeletedLocally(
+                        fixture,
+                        applyResult,
+                        localFeatureSha,
+                    );
+                },
+                gitCleanupIntegrationTimeoutMs,
+            );
+
+            it(
                 'restores the local branch when a hosted origin branch moves after local archive',
                 () => {
                     const fixture = createGitFixture();
@@ -5746,6 +5943,55 @@ describe('git-cleanup CLI', () => {
                         secondClonePath,
                         applyReport,
                         applyResult,
+                    );
+                },
+                gitCleanupIntegrationTimeoutMs,
+            );
+
+            it(
+                'restores hosted origin branches when final validation fails after delete',
+                () => {
+                    const fixture = createGitFixture();
+
+                    createMergedFeatureBranch(fixture.repoPath, 'feature', {
+                        pushRemote: true,
+                    });
+                    const originalFeatureSha = readCurrentSha(
+                        fixture.originPath,
+                        'feature',
+                    );
+                    makeOriginAppearHosted(fixture);
+                    const env = installOriginHeadRepointAfterHostedDelete(
+                        fixture,
+                        'feature',
+                        'alternate-main',
+                    );
+
+                    const auditReport = runGitCleanupJson(
+                        fixture.repoPath,
+                        ['git-cleanup'],
+                        env,
+                    );
+
+                    expectSafeDeleteBranch(auditReport);
+
+                    const applyReport = runGitCleanupJson(
+                        fixture.repoPath,
+                        ['git-cleanup', '--apply'],
+                        env,
+                    );
+                    const applyResult = findApplyResult(applyReport, 'feature');
+
+                    expect(applyResult?.localBranchDeleted).toBe(false);
+                    expect(applyResult?.remoteBranchDeleted).toBe(false);
+                    expect(applyResult?.remoteBranchSkippedReason).toContain(
+                        'live origin branch was restored',
+                    );
+                    expect(readCurrentSha(fixture.repoPath, 'feature')).toBe(
+                        originalFeatureSha,
+                    );
+                    expect(readCurrentSha(fixture.originPath, 'feature')).toBe(
+                        originalFeatureSha,
                     );
                 },
                 gitCleanupIntegrationTimeoutMs,


### PR DESCRIPTION
## Summary

- bump package version to 0.0.6
- harden git-cleanup remote proof validation for no-upstream, hosted, and absent-origin cases
- restore hosted origin branches when post-delete validation fails
- expand git-cleanup regression coverage for remote deletion safety and usability

## Validation

- npm run format
- npm run lint
- npm run typecheck
- npm test