### PR TITLE
[codex] Refine git-cleanup patch-equivalence safety

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "slop-refinery",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "slop-refinery",
-            "version": "0.0.7",
+            "version": "0.0.8",
             "license": "MIT",
             "dependencies": {
                 "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "slop-refinery",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "description": "Refines AI slop into clean code: correct, simple, maintainable",
     "type": "module",
     "license": "MIT",

--- a/src/lib/git-cleanup.ts
+++ b/src/lib/git-cleanup.ts
@@ -20,6 +20,7 @@ type BranchClassification = 'needs_review' | 'protected_base' | 'safe_delete';
 type BranchReasonCode =
     | 'branch_checked_out_in_primary_worktree'
     | 'branch_content_equivalent_to_base'
+    | 'branch_patch_equivalent_to_base'
     | 'branch_reflog_has_unique_commits'
     | 'branch_reflog_unavailable'
     | 'branch_tip_not_on_base'
@@ -42,6 +43,7 @@ type BranchReasonCode =
     | 'origin_branch_live_tip_not_on_base'
     | 'origin_branch_live_tip_unverified'
     | 'origin_branch_non_origin_upstream'
+    | 'origin_branch_patch_equivalent_to_base'
     | 'origin_branch_protected_base'
     | 'origin_branch_tracking_ref_not_on_base'
     | 'repository_hidden_refs_present'
@@ -86,6 +88,7 @@ type RemoteBranchStatus =
     | 'live_tip_not_on_base'
     | 'live_tip_unverified'
     | 'non_origin_upstream'
+    | 'patch_equivalent_to_base'
     | 'protected_base'
     | 'safe'
     | 'tracking_ref_not_on_base';
@@ -199,6 +202,7 @@ type BranchState = {
     linkedWorktreeCount: number;
     mergedByHistory: boolean;
     originBranchStatus: RemoteBranchStatus;
+    patchEquivalentToBase: boolean;
     repositoryHiddenRefCount: number;
     repositoryHiddenRefs: string[];
     repositoryHiddenRefsAvailable: boolean;
@@ -3846,7 +3850,7 @@ function readBranchReflogAnalysis(
 
     const parsedReflog = readReflogShas(reflogPath);
 
-    if (parsedReflog === null || parsedReflog.shas.length === 0) {
+    if (parsedReflog === null) {
         return {
             available: false,
             fingerprint: null,
@@ -3945,19 +3949,27 @@ function countReflogOnlyCommits(
             return null;
         }
 
-        if (
-            !gitSucceeded(repoRoot, [
-                'merge-base',
-                '--is-ancestor',
-                sha,
-                baseRef,
-            ])
-        ) {
+        if (!commitIsPracticallyPreserved(repoRoot, baseRef, sha)) {
             uniqueCommitShas.push(sha);
         }
     }
 
     return uniqueCommitShas.length;
+}
+
+function commitIsPracticallyPreserved(
+    repoRoot: string,
+    baseRef: string,
+    commitSha: string,
+): boolean {
+    return (
+        gitSucceeded(repoRoot, [
+            'merge-base',
+            '--is-ancestor',
+            commitSha,
+            baseRef,
+        ]) || refPatchEquivalentToBase(repoRoot, baseRef, commitSha)
+    );
 }
 
 function assessRemoteBranch(
@@ -4197,6 +4209,7 @@ function remoteBranchStatusHasSafeProof(status: RemoteBranchStatus): boolean {
     return (
         status === 'absent' ||
         status === 'content_equivalent_to_base' ||
+        status === 'patch_equivalent_to_base' ||
         status === 'safe'
     );
 }
@@ -4376,6 +4389,7 @@ function readPresentOriginLiveTipStatus(
     | 'identity_unverified'
     | 'live_tip_not_on_base'
     | 'live_tip_unverified'
+    | 'patch_equivalent_to_base'
     | 'safe'
 > {
     if (isLocalOriginBranchSymbolicRef(repoRoot, base, branch)) {
@@ -4397,8 +4411,12 @@ function readPresentOriginLiveTipStatus(
         return 'safe';
     }
 
-    return refsHaveSameTree(repoRoot, base.liveSha, liveSha)
-        ? 'content_equivalent_to_base'
+    if (refsHaveSameTree(repoRoot, base.liveSha, liveSha)) {
+        return 'content_equivalent_to_base';
+    }
+
+    return refPatchEquivalentToBase(repoRoot, base.liveSha, liveSha)
+        ? 'patch_equivalent_to_base'
         : 'live_tip_not_on_base';
 }
 
@@ -5034,6 +5052,11 @@ function buildBranchState(
         baseRef,
     ]);
     const contentEquivalentToBase = refsHaveSameTree(repoRoot, baseRef, branch);
+    const patchEquivalentToBase = refPatchEquivalentToBase(
+        repoRoot,
+        baseRef,
+        branch,
+    );
     const duplicateTreeRefs = readDuplicateTreeRefs(repoRoot, baseRef, branch);
     const originBranchStatus = remoteBranch?.status ?? 'absent';
     const hasBlockingDetachedWorktree = detachedWorktrees.some(
@@ -5043,11 +5066,12 @@ function buildBranchState(
         readRepositoryLinkedWorktreePaths(worktrees);
     const safeToDelete = isBranchSafeToDelete(
         branch,
-        branchReflogAnalysis.available,
+        branchReflogAnalysis,
         linkedWorktreeFlags,
         branchTipIsPracticallyPreserved(
             mergedByHistory,
             contentEquivalentToBase,
+            patchEquivalentToBase,
         ),
         linkedWorktrees.length,
         remoteBranch,
@@ -5058,6 +5082,7 @@ function buildBranchState(
         linkedWorktreeFlags,
         mergedByHistory,
         contentEquivalentToBase,
+        patchEquivalentToBase,
         linkedWorktrees.length,
         remoteBranch,
     );
@@ -5079,6 +5104,7 @@ function buildBranchState(
         linkedWorktreeCount: linkedWorktrees.length,
         mergedByHistory,
         originBranchStatus,
+        patchEquivalentToBase,
         repositoryHiddenRefCount: hiddenRefAnalysis.refs.length,
         repositoryHiddenRefs: hiddenRefAnalysis.refs,
         repositoryHiddenRefsAvailable: hiddenRefAnalysis.available,
@@ -5106,6 +5132,7 @@ function buildBranchSafetyProofFingerprint(
     linkedWorktreeFlags: ReturnType<typeof readLinkedWorktreeFlags>,
     mergedByHistory: boolean,
     contentEquivalentToBase: boolean,
+    patchEquivalentToBase: boolean,
     linkedWorktreeCount: number,
     remoteBranch: null | RemoteBranchAssessment,
 ): null | string {
@@ -5120,6 +5147,7 @@ function buildBranchSafetyProofFingerprint(
             linkedWorktreeCount,
             linkedWorktreeFlags,
             mergedByHistory,
+            patchEquivalentToBase,
             remoteBranch,
         }),
     );
@@ -5164,6 +5192,23 @@ function readTreeSha(repoRoot: string, ref: string): null | string {
     const result = tryGit(repoRoot, ['rev-parse', `${ref}^{tree}`]);
 
     return result.ok && result.stdout !== '' ? result.stdout : null;
+}
+
+function refPatchEquivalentToBase(
+    repoRoot: string,
+    baseRef: string,
+    ref: string,
+): boolean {
+    const result = tryGit(repoRoot, ['cherry', baseRef, ref]);
+
+    if (!result.ok) {
+        return false;
+    }
+
+    return result.stdout
+        .split('\n')
+        .filter((line) => line !== '')
+        .every((line) => line.startsWith('-'));
 }
 
 function readDuplicateTreeRefs(
@@ -5260,14 +5305,15 @@ function readWorktreesSafely(repoPath: string): null | WorktreeInfo[] {
 
 function isBranchSafeToDelete(
     branch: string,
-    branchReflogAvailable: boolean,
+    branchReflogAnalysis: ReflogAnalysis,
     linkedWorktreeFlags: ReturnType<typeof readLinkedWorktreeFlags>,
     branchTipPreserved: boolean,
     linkedWorktreeCount: number,
     remoteBranch: null | RemoteBranchAssessment,
 ): boolean {
     return (
-        branchReflogAvailable &&
+        branchReflogAnalysis.available &&
+        branchReflogAnalysis.uniqueCommitCount === 0 &&
         branchTipPreserved &&
         isRemoteBranchSafeToDelete(branch, remoteBranch) &&
         hasNoBlockingLinkedWorktrees(linkedWorktreeCount, linkedWorktreeFlags)
@@ -5277,8 +5323,9 @@ function isBranchSafeToDelete(
 function branchTipIsPracticallyPreserved(
     mergedByHistory: boolean,
     contentEquivalentToBase: boolean,
+    patchEquivalentToBase: boolean,
 ): boolean {
-    return mergedByHistory || contentEquivalentToBase;
+    return mergedByHistory || contentEquivalentToBase || patchEquivalentToBase;
 }
 
 function hasNoBlockingLinkedWorktrees(
@@ -5331,9 +5378,13 @@ function remoteBranchStatusIsSafeForDelete(
     status: RemoteBranchStatus,
 ): status is Extract<
     RemoteBranchStatus,
-    'content_equivalent_to_base' | 'safe'
+    'content_equivalent_to_base' | 'patch_equivalent_to_base' | 'safe'
 > {
-    return status === 'safe' || status === 'content_equivalent_to_base';
+    return (
+        status === 'safe' ||
+        status === 'content_equivalent_to_base' ||
+        status === 'patch_equivalent_to_base'
+    );
 }
 
 function summarizeBranchActivity(
@@ -5353,6 +5404,10 @@ function summarizeBranchActivity(
 
     if (state.contentEquivalentToBase) {
         return `the branch tip is not reachable from ${baseShort}, but its file tree matches ${baseShort}; latest commit is ${latestCommit} from ${lastCommit.dateIso.slice(0, 10)}.`;
+    }
+
+    if (state.patchEquivalentToBase) {
+        return `the branch tip is not reachable from ${baseShort}, but its patch is already represented on ${baseShort}; latest commit is ${latestCommit} from ${lastCommit.dateIso.slice(0, 10)}.`;
     }
 
     return `${state.uniqueCommitCount} commit(s) are still not reachable from ${baseShort}; latest commit is ${latestCommit} from ${lastCommit.dateIso.slice(0, 10)}.`;
@@ -5440,24 +5495,22 @@ function decideBranchOpinion(
     lastCommit: CommitInfo,
     state: BranchState,
 ): Opinion {
-    if (
-        state.safeToDelete &&
-        state.contentEquivalentToBase &&
-        !state.branchTipOnBase
-    ) {
-        return {
-            code: 'delete',
-            label: 'delete',
-            reason: 'the local branch and any auto-deletable origin branch have the same file content as the canonical origin default branch, and the branch is not checked out in any worktree.',
-        };
+    if (branchCanDeleteByContentEquivalence(state)) {
+        return buildDeleteOpinion(
+            'the local branch and any auto-deletable origin branch have the same file content as the canonical origin default branch, and the branch is not checked out in any worktree.',
+        );
+    }
+
+    if (branchCanDeleteByPatchEquivalence(state)) {
+        return buildDeleteOpinion(
+            'the local branch and any auto-deletable origin branch have changes already represented on the canonical origin default branch, and the branch is not checked out in any worktree.',
+        );
     }
 
     if (state.safeToDelete) {
-        return {
-            code: 'delete',
-            label: 'delete',
-            reason: 'the local branch and any auto-deletable origin branch are proven preserved on the canonical origin default branch, and the branch is not checked out in any worktree.',
-        };
+        return buildDeleteOpinion(
+            'the local branch and any auto-deletable origin branch are proven preserved on the canonical origin default branch, and the branch is not checked out in any worktree.',
+        );
     }
 
     if (isKeptOnlyByProofGaps(state)) {
@@ -5487,6 +5540,30 @@ function decideBranchOpinion(
         code: 'needs_human_review',
         label: 'needs human review',
         reason: 'git-cleanup cannot prove that every reachable or reflog-only commit is already preserved on origin’s canonical default branch.',
+    };
+}
+
+function branchCanDeleteByContentEquivalence(state: BranchState): boolean {
+    return (
+        state.safeToDelete &&
+        state.contentEquivalentToBase &&
+        !state.branchTipOnBase
+    );
+}
+
+function branchCanDeleteByPatchEquivalence(state: BranchState): boolean {
+    return (
+        state.safeToDelete &&
+        state.patchEquivalentToBase &&
+        !state.branchTipOnBase
+    );
+}
+
+function buildDeleteOpinion(reason: string): Opinion {
+    return {
+        code: 'delete',
+        label: 'delete',
+        reason,
     };
 }
 
@@ -5526,6 +5603,11 @@ function collectBranchReasonCodes(
         ...(state.contentEquivalentToBase && !state.branchTipOnBase
             ? (['branch_content_equivalent_to_base'] as const)
             : []),
+        ...(state.patchEquivalentToBase &&
+        !state.contentEquivalentToBase &&
+        !state.branchTipOnBase
+            ? (['branch_patch_equivalent_to_base'] as const)
+            : []),
         ...(state.safeToDelete ? [] : readBranchReflogReasonCodes(state)),
         ...(!state.safeToDelete && state.hasBlockingDetachedWorktree
             ? (['detached_worktree_requires_manual_review'] as const)
@@ -5557,7 +5639,7 @@ function readOriginBranchReasonCodes(
 ): BranchReasonCode[] {
     const reasonCode = readOriginBranchReasonCode(status);
     const targetMismatchReasonCode: BranchReasonCode | null =
-        (status === 'safe' || status === 'absent') &&
+        (status === 'absent' || remoteBranchStatusIsSafeForDelete(status)) &&
         remoteBranch !== null &&
         remoteBranch.branch !== branch
             ? 'origin_branch_delete_target_mismatch'
@@ -5589,6 +5671,7 @@ function readOriginBranchReasonCode(
         live_tip_not_on_base: 'origin_branch_live_tip_not_on_base',
         live_tip_unverified: 'origin_branch_live_tip_unverified',
         non_origin_upstream: 'origin_branch_non_origin_upstream',
+        patch_equivalent_to_base: 'origin_branch_patch_equivalent_to_base',
         protected_base: 'origin_branch_protected_base',
         tracking_ref_not_on_base: 'origin_branch_tracking_ref_not_on_base',
     };
@@ -5681,6 +5764,12 @@ function readBranchTipReasonDetails(
         ];
     }
 
+    if (state.patchEquivalentToBase) {
+        return [
+            `the branch tip is not reachable from ${baseShort}, but its patch is already represented on ${baseShort}.`,
+        ];
+    }
+
     if (!state.hasCommonAncestor) {
         return [
             `the branch does not share a common ancestor with ${baseShort}.`,
@@ -5714,12 +5803,12 @@ function buildBranchReflogReasonDetails(
 
     if (state.branchReflogUniqueCommitCount > 0) {
         return [
-            `the branch reflog still references ${state.branchReflogUniqueCommitCount} commit(s) that are not reachable from ${baseShort}.`,
+            `the branch reflog still references ${state.branchReflogUniqueCommitCount} commit(s) whose changes are not already represented on ${baseShort}.`,
         ];
     }
 
     return [
-        `the branch reflog does not reference any commits that are still outside ${baseShort}.`,
+        `the branch reflog does not reference any commits whose changes are still outside ${baseShort}.`,
     ];
 }
 
@@ -5741,7 +5830,7 @@ function readRemoteReasonDetail(
     const remoteName = remoteBranch?.shortName ?? 'origin branch';
 
     if (
-        (status === 'safe' || status === 'absent') &&
+        (status === 'absent' || remoteBranchStatusIsSafeForDelete(status)) &&
         remoteBranch !== null &&
         remoteBranch.branch !== branch
     ) {
@@ -5770,6 +5859,7 @@ function readRemoteReasonDetail(
         live_tip_not_on_base: `the live origin branch ${remoteName} still points to commits that are not reachable from ${baseShort}.`,
         live_tip_unverified: `the live origin branch ${remoteName} could not be verified against the local remote-tracking ref. Fetch origin before manual remote cleanup.`,
         non_origin_upstream: `the branch tracks ${remoteName}, but only origin’s default branch is treated as canonical history.`,
+        patch_equivalent_to_base: `the live origin branch ${remoteName} is not reachable from ${baseShort}, but its patch is already represented on ${baseShort}.`,
         protected_base: `the tracked origin branch ${remoteName} is the canonical default branch and is protected from deletion.`,
         safe: `the live origin branch ${remoteName} matches the local tracking ref and is already reachable from ${baseShort}.`,
         tracking_ref_not_on_base: `the live origin branch ${remoteName} is gone, but the remaining local origin-tracking ref is still not reachable from ${baseShort}.`,
@@ -10480,6 +10570,7 @@ function readRemoteDeleteSkippedReason(
         live_probe_unverified: `the live origin branch ${remoteShortName} could not be probed successfully, so remote deletion was skipped.`,
         live_tip_unverified: `the live origin branch ${remoteShortName} could not be verified against the local remote-tracking ref; remote deletion was skipped.`,
         non_origin_upstream: `the branch tracks ${remoteShortName}, but only origin branches are eligible for automatic remote deletion.`,
+        patch_equivalent_to_base: `the live origin branch ${remoteShortName} is patch-equivalent to ${baseShort}, but remote deletion was skipped by this validation path.`,
         protected_base: `the live origin branch ${remoteShortName} is the canonical default branch and is protected from deletion.`,
         tracking_ref_not_on_base: `the remaining local origin-tracking ref for ${remoteShortName} is still not reachable from ${baseShort}, so remote deletion was skipped.`,
     };
@@ -10890,7 +10981,9 @@ function readRemoteArchivePreflightSkippedReason(
         '--is-ancestor',
         liveSha,
         latestBase.liveSha,
-    ]) || refsHaveSameTree(remoteRepoPath, latestBase.liveSha, liveSha)
+    ]) ||
+        refsHaveSameTree(remoteRepoPath, latestBase.liveSha, liveSha) ||
+        refPatchEquivalentToBase(remoteRepoPath, latestBase.liveSha, liveSha)
         ? null
         : `the live origin branch ${remoteShortName} is no longer reachable from ${latestBase.shortName}; remote deletion was skipped.`;
 }
@@ -11255,7 +11348,7 @@ function renderBranchSection(
         `- Reason codes: ${renderReasonCodes(branch.reasonCodes)}`,
         `- Opinion: \`${branch.opinion.code}\` because ${branch.opinion.reason}`,
         `- Activity: ${branch.activity}`,
-        `- State: safeToDelete=${branch.state.safeToDelete}, branchTipOnBase=${branch.state.branchTipOnBase}, contentEquivalentToBase=${branch.state.contentEquivalentToBase}, mergedByHistory=${branch.state.mergedByHistory}, uniqueCommitCount=${branch.state.uniqueCommitCount}, branchReflogAvailable=${branch.state.branchReflogAvailable}, branchReflogUniqueCommitCount=${branch.state.branchReflogUniqueCommitCount}, repositoryLinkedWorktrees=${branch.state.repositoryLinkedWorktreeCount}, repositoryUnreachableCommitsAvailable=${branch.state.repositoryUnreachableCommitsAvailable}, repositoryUnreachableCommitCount=${branch.state.repositoryUnreachableCommitCount}, originBranchStatus=${branch.state.originBranchStatus}, duplicateTreeRefs=${branch.state.duplicateTreeRefs.length}, ahead=${branch.state.aheadCount}, behind=${branch.state.behindCount}, linkedWorktrees=${branch.state.linkedWorktreeCount}`,
+        `- State: safeToDelete=${branch.state.safeToDelete}, branchTipOnBase=${branch.state.branchTipOnBase}, contentEquivalentToBase=${branch.state.contentEquivalentToBase}, patchEquivalentToBase=${branch.state.patchEquivalentToBase}, mergedByHistory=${branch.state.mergedByHistory}, uniqueCommitCount=${branch.state.uniqueCommitCount}, branchReflogAvailable=${branch.state.branchReflogAvailable}, branchReflogUniqueCommitCount=${branch.state.branchReflogUniqueCommitCount}, repositoryLinkedWorktrees=${branch.state.repositoryLinkedWorktreeCount}, repositoryUnreachableCommitsAvailable=${branch.state.repositoryUnreachableCommitsAvailable}, repositoryUnreachableCommitCount=${branch.state.repositoryUnreachableCommitCount}, originBranchStatus=${branch.state.originBranchStatus}, duplicateTreeRefs=${branch.state.duplicateTreeRefs.length}, ahead=${branch.state.aheadCount}, behind=${branch.state.behindCount}, linkedWorktrees=${branch.state.linkedWorktreeCount}`,
         renderRemoteBranch(branch.remoteBranch),
     ];
 

--- a/tests/git-cleanup.test.ts
+++ b/tests/git-cleanup.test.ts
@@ -275,6 +275,49 @@ function createIgnoredOnlyWorktreeFixture(fixture: GitFixture): void {
     writeFile(path.join(ignoredDirectory, 'generated.txt'), 'x\n');
 }
 
+function createHostedPatchEquivalentBranch(fixture: GitFixture): void {
+    git(fixture.repoPath, ['checkout', '-b', 'feature'], false);
+    commitFile(
+        fixture.repoPath,
+        'feature.txt',
+        'feature\n',
+        'Create feature work',
+    );
+    git(fixture.repoPath, ['push', '-u', 'origin', 'feature'], false);
+    git(fixture.repoPath, ['checkout', 'main'], false);
+    commitFile(
+        fixture.repoPath,
+        'feature.txt',
+        'feature\n',
+        'Squash feature content',
+    );
+    commitFile(
+        fixture.repoPath,
+        'main-only.txt',
+        'main-only\n',
+        'Advance main after squash',
+    );
+    git(fixture.repoPath, ['push', 'origin', 'main'], false);
+    git(fixture.repoPath, ['fetch', 'origin'], false);
+    makeOriginAppearHosted(fixture);
+}
+
+function createResetFeatureWithNonEquivalentReflog(cwd: string): void {
+    git(cwd, ['checkout', '-b', 'feature'], false);
+    commitFile(cwd, 'feature.txt', 'feature\n', 'Create feature work');
+    git(cwd, ['checkout', 'main'], false);
+    git(cwd, ['branch', '-f', 'feature', 'main'], false);
+}
+
+function createResetFeatureWithPatchEquivalentReflog(cwd: string): void {
+    git(cwd, ['checkout', '-b', 'feature'], false);
+    commitFile(cwd, 'feature.txt', 'feature\n', 'Create feature work');
+    git(cwd, ['checkout', 'main'], false);
+    commitFile(cwd, 'feature.txt', 'feature\n', 'Squash feature content');
+    git(cwd, ['push', 'origin', 'main'], false);
+    git(cwd, ['branch', '-f', 'feature', 'main'], false);
+}
+
 function createUnmergedRemoteBranch(cwd: string, branchName: string): void {
     git(cwd, ['checkout', '-b', branchName], false);
     commitFile(
@@ -2684,6 +2727,43 @@ describe('git-cleanup CLI', () => {
             },
             gitCleanupIntegrationTimeoutMs,
         );
+
+        it(
+            'applies cleanup to a hosted branch whose commits are patch-equivalent to main',
+            () => {
+                const fixture = createGitFixture();
+
+                createHostedPatchEquivalentBranch(fixture);
+                const remoteFeatureSha = readCurrentSha(
+                    fixture.originPath,
+                    'feature',
+                );
+
+                const auditReport = runGitCleanupJson(fixture.repoPath, [
+                    'git-cleanup',
+                ]);
+                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
+
+                expect(safeDeleteBranch.state.patchEquivalentToBase).toBe(true);
+                expect(safeDeleteBranch.remoteBranch?.status).toBe(
+                    'patch_equivalent_to_base',
+                );
+
+                const applyReport = runGitCleanupJson(fixture.repoPath, [
+                    'git-cleanup',
+                    '--apply',
+                    '--keep-archives',
+                ]);
+                const applyResult = findApplyResult(applyReport, 'feature');
+
+                expectHostedFeatureDeletedLocallyAndRemotely(
+                    fixture,
+                    applyResult,
+                    remoteFeatureSha,
+                );
+            },
+            gitCleanupIntegrationTimeoutMs,
+        );
     });
 
     describe('branch and remote classification', () => {
@@ -3950,6 +4030,36 @@ describe('git-cleanup CLI', () => {
         );
 
         it(
+            'marks a hosted branch safe when its commits are patch-equivalent to main',
+            () => {
+                const fixture = createGitFixture();
+
+                createHostedPatchEquivalentBranch(fixture);
+
+                const auditReport = runGitCleanupJson(fixture.repoPath, [
+                    'git-cleanup',
+                ]);
+                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
+
+                expect(safeDeleteBranch.state.branchTipOnBase).toBe(false);
+                expect(safeDeleteBranch.state.contentEquivalentToBase).toBe(
+                    false,
+                );
+                expect(safeDeleteBranch.state.patchEquivalentToBase).toBe(true);
+                expect(safeDeleteBranch.remoteBranch?.status).toBe(
+                    'patch_equivalent_to_base',
+                );
+                expect(safeDeleteBranch.reasonCodes).toEqual(
+                    expect.arrayContaining([
+                        'branch_patch_equivalent_to_base',
+                        'origin_branch_patch_equivalent_to_base',
+                    ]),
+                );
+            },
+            gitCleanupIntegrationTimeoutMs,
+        );
+
+        it(
             'reports duplicate-tree hints for branches with matching file content',
             () => {
                 const fixture = createGitFixture();
@@ -4395,607 +4505,654 @@ describe('git-cleanup CLI', () => {
         );
     });
 
-    describe('local worktree safety', () => {
-        it(
-            'still marks a safe branch deleteable when an unrelated repository worktree is dirty',
-            () => {
-                const fixture = createGitFixture();
+    describe('local safety', () => {
+        describe('local worktree safety', () => {
+            it(
+                'still marks a safe branch deleteable when an unrelated repository worktree is dirty',
+                () => {
+                    const fixture = createGitFixture();
 
-                createMergedFeatureBranch(fixture.repoPath, 'feature', {
-                    pushRemote: true,
-                });
-                writeFile(
-                    path.join(fixture.repoPath, 'dirty-main.txt'),
-                    'dirty\n',
-                );
+                    createMergedFeatureBranch(fixture.repoPath, 'feature', {
+                        pushRemote: true,
+                    });
+                    writeFile(
+                        path.join(fixture.repoPath, 'dirty-main.txt'),
+                        'dirty\n',
+                    );
 
-                const auditReport = runGitCleanupJson(fixture.repoPath, [
-                    'git-cleanup',
-                ]);
-                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
+                    const auditReport = runGitCleanupJson(fixture.repoPath, [
+                        'git-cleanup',
+                    ]);
+                    const safeDeleteBranch =
+                        expectSafeDeleteBranch(auditReport);
 
-                expect(
-                    safeDeleteBranch.state.repositoryWorktreeDirtyCount,
-                ).toBe(1);
-            },
-            gitCleanupIntegrationTimeoutMs,
-        );
+                    expect(
+                        safeDeleteBranch.state.repositoryWorktreeDirtyCount,
+                    ).toBe(1);
+                },
+                gitCleanupIntegrationTimeoutMs,
+            );
+        });
 
-        it(
-            'keeps a merged branch deleteable when its reflog points at a local-only commit',
-            () => {
-                const fixture = createGitFixture();
+        describe('local branch reflog safety', () => {
+            it(
+                'keeps a merged branch for review when its reflog points at a non-equivalent local-only commit',
+                () => {
+                    const fixture = createGitFixture();
 
-                git(fixture.repoPath, ['checkout', '-b', 'feature'], false);
-                commitFile(
-                    fixture.repoPath,
-                    'feature.txt',
-                    'feature\n',
-                    'Create feature work',
-                );
-                git(fixture.repoPath, ['checkout', 'main'], false);
-                git(
-                    fixture.repoPath,
-                    ['branch', '-f', 'feature', 'main'],
-                    false,
-                );
+                    createResetFeatureWithNonEquivalentReflog(fixture.repoPath);
 
-                const auditReport = runGitCleanupJson(fixture.repoPath, [
-                    'git-cleanup',
-                ]);
-                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
+                    const auditReport = runGitCleanupJson(fixture.repoPath, [
+                        'git-cleanup',
+                    ]);
+                    const reviewBranch = findBranchReport(
+                        auditReport,
+                        'needsReview',
+                        'feature',
+                    );
 
-                expect(
-                    safeDeleteBranch.state.branchReflogUniqueCommitCount,
-                ).toBeGreaterThan(0);
-                expect(safeDeleteBranch.reasonCodes).not.toContain(
-                    'branch_reflog_has_unique_commits',
-                );
-                expect(
-                    findBranchReport(auditReport, 'needsReview', 'feature'),
-                ).toBe(undefined);
-            },
-            gitCleanupIntegrationTimeoutMs,
-        );
+                    expect(
+                        reviewBranch?.state.branchReflogUniqueCommitCount,
+                    ).toBeGreaterThan(0);
+                    expect(reviewBranch?.reasonCodes).toContain(
+                        'branch_reflog_has_unique_commits',
+                    );
+                    expect(
+                        findBranchReport(auditReport, 'safeDelete', 'feature'),
+                    ).toBe(undefined);
+                },
+                gitCleanupIntegrationTimeoutMs,
+            );
 
-        it(
-            'fails closed when a branch reflog contains a malformed entry',
-            () => {
-                const fixture = createGitFixture();
+            it(
+                'keeps a merged branch deleteable when its reflog only points at patch-equivalent commits',
+                () => {
+                    const fixture = createGitFixture();
 
-                createMergedFeatureBranch(fixture.repoPath, 'feature', {
-                    pushRemote: true,
-                });
-                writeFileSync(
-                    path.join(
-                        readGitCommonDir(fixture.repoPath),
-                        'logs',
+                    createResetFeatureWithPatchEquivalentReflog(
+                        fixture.repoPath,
+                    );
+
+                    const auditReport = runGitCleanupJson(fixture.repoPath, [
+                        'git-cleanup',
+                    ]);
+                    const safeDeleteBranch =
+                        expectSafeDeleteBranch(auditReport);
+
+                    expect(
+                        safeDeleteBranch.state.branchReflogUniqueCommitCount,
+                    ).toBe(0);
+                    expect(safeDeleteBranch.reasonCodes).not.toContain(
+                        'branch_reflog_has_unique_commits',
+                    );
+                    expect(
+                        findBranchReport(auditReport, 'needsReview', 'feature'),
+                    ).toBe(undefined);
+                },
+                gitCleanupIntegrationTimeoutMs,
+            );
+
+            it(
+                'fails closed when a branch reflog contains a malformed entry',
+                () => {
+                    const fixture = createGitFixture();
+
+                    createMergedFeatureBranch(fixture.repoPath, 'feature', {
+                        pushRemote: true,
+                    });
+                    writeFileSync(
+                        path.join(
+                            readGitCommonDir(fixture.repoPath),
+                            'logs',
+                            'refs',
+                            'heads',
+                            'feature',
+                        ),
+                        'notasha also-notasha corrupt\n',
+                        { flag: 'a' },
+                    );
+
+                    const auditReport = runGitCleanupJson(fixture.repoPath, [
+                        'git-cleanup',
+                    ]);
+                    const reviewBranch = findBranchReport(
+                        auditReport,
+                        'needsReview',
+                        'feature',
+                    );
+
+                    expect(reviewBranch?.reasonCodes).toContain(
+                        'branch_reflog_unavailable',
+                    );
+                    expect(
+                        findBranchReport(auditReport, 'safeDelete', 'feature'),
+                    ).toBeUndefined();
+                },
+                gitCleanupIntegrationTimeoutMs,
+            );
+        });
+
+        describe('repository reflog and archive safety', () => {
+            it(
+                'still marks a safe branch deleteable when unrelated repository-wide reflogs retain non-base history',
+                () => {
+                    const fixture = createGitFixture();
+
+                    createMergedFeatureBranch(fixture.repoPath, 'feature');
+                    createMovedTagReflogHistoryNotOnBase(
+                        fixture.repoPath,
+                        'retained-history',
+                    );
+
+                    const auditReport = runGitCleanupJson(fixture.repoPath, [
+                        'git-cleanup',
+                    ]);
+                    const safeDeleteBranch =
+                        expectSafeDeleteBranch(auditReport);
+
+                    expect(
+                        safeDeleteBranch.state
+                            .repositoryReflogUniqueCommitCount,
+                    ).toBeGreaterThan(0);
+                },
+                gitCleanupIntegrationTimeoutMs,
+            );
+
+            it(
+                'still marks a safe branch deleteable when an unrelated linked worktree HEAD reflog retains non-base history',
+                () => {
+                    const fixture = createGitFixture();
+                    const linkedWorktreePath = path.join(
+                        fixture.tempPath,
+                        'topic-worktree',
+                    );
+
+                    createMergedFeatureBranch(fixture.repoPath, 'feature');
+                    createAttachedLinkedWorktreeWithDetachedHeadHistory(
+                        fixture,
+                        'topic',
+                        linkedWorktreePath,
+                    );
+
+                    const auditReport = runGitCleanupJson(fixture.repoPath, [
+                        'git-cleanup',
+                    ]);
+                    const safeDeleteBranch =
+                        expectSafeDeleteBranch(auditReport);
+
+                    expect(
+                        safeDeleteBranch.state
+                            .repositoryReflogUniqueCommitCount,
+                    ).toBeGreaterThan(0);
+                    expect(
+                        safeDeleteBranch.state.repositoryLinkedWorktreePaths,
+                    ).toContain(realpathSync(linkedWorktreePath));
+                },
+                gitCleanupIntegrationTimeoutMs,
+            );
+
+            it(
+                'still marks a safe branch deleteable when an unrelated dirty linked worktree path contains a newline',
+                () => {
+                    const fixture = createGitFixture();
+                    const cleanSiblingPath = path.join(
+                        fixture.tempPath,
+                        'newline-worktree',
+                    );
+                    const newlineWorktreePath = `${cleanSiblingPath}\nspoof`;
+
+                    createMergedFeatureBranch(fixture.repoPath, 'feature');
+                    git(
+                        fixture.repoPath,
+                        ['branch', 'clean-topic', 'main'],
+                        false,
+                    );
+                    git(
+                        fixture.repoPath,
+                        ['branch', 'dirty-topic', 'main'],
+                        false,
+                    );
+                    git(
+                        fixture.repoPath,
+                        ['worktree', 'add', cleanSiblingPath, 'clean-topic'],
+                        false,
+                    );
+                    git(
+                        fixture.repoPath,
+                        ['worktree', 'add', newlineWorktreePath, 'dirty-topic'],
+                        false,
+                    );
+                    writeFile(
+                        path.join(newlineWorktreePath, 'untracked.txt'),
+                        'dirty\n',
+                    );
+
+                    const auditReport = runGitCleanupJson(fixture.repoPath, [
+                        'git-cleanup',
+                    ]);
+                    const safeDeleteBranch =
+                        expectSafeDeleteBranch(auditReport);
+
+                    expect(
+                        safeDeleteBranch.state.repositoryWorktreeDirtyPaths.some(
+                            (dirtyPath) => dirtyPath.includes('\nspoof'),
+                        ),
+                    ).toBe(true);
+                },
+                gitCleanupIntegrationTimeoutMs,
+            );
+
+            it(
+                'still marks a safe branch deleteable when an unrelated worktree-private ref points outside main',
+                () => {
+                    const fixture = createGitFixture();
+                    const linkedWorktreePath = path.join(
+                        fixture.tempPath,
+                        'private-ref-worktree',
+                    );
+
+                    createMergedFeatureBranch(fixture.repoPath, 'feature');
+                    git(fixture.repoPath, ['branch', 'topic', 'main'], false);
+                    git(
+                        fixture.repoPath,
+                        ['worktree', 'add', linkedWorktreePath, 'topic'],
+                        false,
+                    );
+                    git(linkedWorktreePath, ['checkout', '--detach'], false);
+                    commitFile(
+                        linkedWorktreePath,
+                        'private-ref.txt',
+                        'private-ref\n',
+                        'Create private ref work',
+                    );
+                    git(
+                        linkedWorktreePath,
+                        ['update-ref', 'refs/worktree/private-ref', 'HEAD'],
+                        false,
+                    );
+                    git(linkedWorktreePath, ['checkout', 'topic'], false);
+                    rmSync(
+                        path.join(
+                            readAbsoluteGitDir(linkedWorktreePath),
+                            'logs',
+                            'HEAD',
+                        ),
+                        { force: true },
+                    );
+
+                    const auditReport = runGitCleanupJson(fixture.repoPath, [
+                        'git-cleanup',
+                    ]);
+                    const safeDeleteBranch =
+                        expectSafeDeleteBranch(auditReport);
+
+                    expect(
+                        safeDeleteBranch.state.repositoryHiddenRefs.some(
+                            (ref) => ref.endsWith('/refs/worktree/private-ref'),
+                        ),
+                    ).toBe(true);
+                },
+                gitCleanupIntegrationTimeoutMs,
+            );
+
+            it(
+                'still marks a safe branch deleteable when an unrelated worktree-private ref reflog retains history outside main',
+                () => {
+                    const fixture = createGitFixture();
+                    const linkedWorktreePath = path.join(
+                        fixture.tempPath,
+                        'private-reflog-worktree',
+                    );
+
+                    createMergedFeatureBranch(fixture.repoPath, 'feature');
+                    git(fixture.repoPath, ['branch', 'topic', 'main'], false);
+                    git(
+                        fixture.repoPath,
+                        ['worktree', 'add', linkedWorktreePath, 'topic'],
+                        false,
+                    );
+                    git(linkedWorktreePath, ['checkout', '--detach'], false);
+                    commitFile(
+                        linkedWorktreePath,
+                        'private-reflog.txt',
+                        'private-reflog\n',
+                        'Create private reflog work',
+                    );
+                    git(
+                        linkedWorktreePath,
+                        [
+                            'update-ref',
+                            '--create-reflog',
+                            'refs/worktree/private-reflog',
+                            'HEAD',
+                        ],
+                        false,
+                    );
+                    git(
+                        linkedWorktreePath,
+                        ['update-ref', 'refs/worktree/private-reflog', 'topic'],
+                        false,
+                    );
+                    git(linkedWorktreePath, ['checkout', 'topic'], false);
+                    rmSync(
+                        path.join(
+                            readAbsoluteGitDir(linkedWorktreePath),
+                            'logs',
+                            'HEAD',
+                        ),
+                        { force: true },
+                    );
+
+                    const auditReport = runGitCleanupJson(fixture.repoPath, [
+                        'git-cleanup',
+                    ]);
+                    const safeDeleteBranch =
+                        expectSafeDeleteBranch(auditReport);
+
+                    expect(
+                        safeDeleteBranch.state
+                            .repositoryReflogUniqueCommitCount,
+                    ).toBeGreaterThan(0);
+                },
+                gitCleanupIntegrationTimeoutMs,
+            );
+
+            it(
+                'still marks a safe branch deleteable when another live off-base branch has no reflog',
+                () => {
+                    const fixture = createGitFixture();
+
+                    createMergedFeatureBranch(fixture.repoPath, 'feature');
+                    git(fixture.repoPath, ['checkout', '-b', 'topic'], false);
+                    commitFile(
+                        fixture.repoPath,
+                        'topic.txt',
+                        'topic\n',
+                        'Create topic work',
+                    );
+                    git(fixture.repoPath, ['checkout', 'main'], false);
+                    removeRefReflog(fixture.repoPath, 'refs', 'heads', 'topic');
+
+                    const auditReport = runGitCleanupJson(fixture.repoPath, [
+                        'git-cleanup',
+                    ]);
+                    const safeDeleteBranch =
+                        expectSafeDeleteBranch(auditReport);
+
+                    expect(
+                        safeDeleteBranch.state.repositoryHiddenRefs,
+                    ).toContain('refs/heads/topic');
+                },
+                gitCleanupIntegrationTimeoutMs,
+            );
+
+            it(
+                'fails closed when archived local branch validation loses the preserving reflog',
+                () => {
+                    const fixture = createGitFixture();
+                    const archivedBranchName =
+                        'slop-refinery/archive/local/feature/manual-check';
+
+                    createMergedFeatureBranch(fixture.repoPath, 'feature', {
+                        pushRemote: true,
+                    });
+                    git(
+                        fixture.repoPath,
+                        ['branch', '-m', 'feature', archivedBranchName],
+                        false,
+                    );
+                    removeRefReflog(
+                        fixture.repoPath,
                         'refs',
                         'heads',
+                        ...archivedBranchName.split('/'),
+                    );
+
+                    const archivedBranchValidation =
+                        validateArchivedBranchForTesting(
+                            fixture.repoPath,
+                            'feature',
+                            archivedBranchName,
+                            readCurrentSha(
+                                fixture.repoPath,
+                                archivedBranchName,
+                            ),
+                        );
+
+                    expect(archivedBranchValidation.archived).toBe(false);
+                    expect(
+                        archivedBranchValidation.errors.some((error) =>
+                            error.includes('reflog'),
+                        ),
+                    ).toBe(true);
+                },
+                gitCleanupIntegrationTimeoutMs,
+            );
+
+            it(
+                'fails closed when archived local branch validation sees a symbolic archive ref',
+                () => {
+                    const fixture = createGitFixture();
+                    const archivedBranchName =
+                        'slop-refinery/archive/local/feature/manual-symbolic-check';
+
+                    createMergedFeatureBranch(fixture.repoPath, 'feature');
+                    const expectedBranchSha = readCurrentSha(
+                        fixture.repoPath,
                         'feature',
-                    ),
-                    'notasha also-notasha corrupt\n',
-                    { flag: 'a' },
-                );
+                    );
+                    git(fixture.repoPath, ['branch', '-D', 'feature'], false);
+                    git(
+                        fixture.repoPath,
+                        [
+                            'symbolic-ref',
+                            `refs/heads/${archivedBranchName}`,
+                            'refs/heads/main',
+                        ],
+                        false,
+                    );
 
-                const auditReport = runGitCleanupJson(fixture.repoPath, [
-                    'git-cleanup',
-                ]);
-                const reviewBranch = findBranchReport(
-                    auditReport,
-                    'needsReview',
-                    'feature',
-                );
+                    const archivedBranchValidation =
+                        validateArchivedBranchForTesting(
+                            fixture.repoPath,
+                            'feature',
+                            archivedBranchName,
+                            expectedBranchSha,
+                        );
 
-                expect(reviewBranch?.reasonCodes).toContain(
-                    'branch_reflog_unavailable',
-                );
-                expect(
-                    findBranchReport(auditReport, 'safeDelete', 'feature'),
-                ).toBeUndefined();
-            },
-            gitCleanupIntegrationTimeoutMs,
-        );
+                    expect(archivedBranchValidation.archived).toBe(false);
+                    expect(
+                        archivedBranchValidation.errors.some((error) =>
+                            error.includes('symbolic'),
+                        ),
+                    ).toBe(true);
+                },
+                gitCleanupIntegrationTimeoutMs,
+            );
 
-        it(
-            'still marks a safe branch deleteable when unrelated repository-wide reflogs retain non-base history',
-            () => {
-                const fixture = createGitFixture();
+            it(
+                'fails closed when archived local branch validation sees a symbolic original ref',
+                () => {
+                    const fixture = createGitFixture();
+                    const archivedBranchName =
+                        'slop-refinery/archive/local/feature/manual-original-symbolic-check';
 
-                createMergedFeatureBranch(fixture.repoPath, 'feature');
-                createMovedTagReflogHistoryNotOnBase(
-                    fixture.repoPath,
-                    'retained-history',
-                );
+                    createMergedFeatureBranch(fixture.repoPath, 'feature');
+                    const expectedBranchSha = readCurrentSha(
+                        fixture.repoPath,
+                        'feature',
+                    );
+                    git(
+                        fixture.repoPath,
+                        ['branch', '-m', 'feature', archivedBranchName],
+                        false,
+                    );
+                    git(
+                        fixture.repoPath,
+                        [
+                            'symbolic-ref',
+                            'refs/heads/feature',
+                            'refs/heads/missing-target',
+                        ],
+                        false,
+                    );
 
-                const auditReport = runGitCleanupJson(fixture.repoPath, [
-                    'git-cleanup',
-                ]);
-                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
+                    const archivedBranchValidation =
+                        validateArchivedBranchForTesting(
+                            fixture.repoPath,
+                            'feature',
+                            archivedBranchName,
+                            expectedBranchSha,
+                        );
 
-                expect(
-                    safeDeleteBranch.state.repositoryReflogUniqueCommitCount,
-                ).toBeGreaterThan(0);
-            },
-            gitCleanupIntegrationTimeoutMs,
-        );
+                    expect(archivedBranchValidation.archived).toBe(false);
+                    expect(
+                        archivedBranchValidation.errors.some((error) =>
+                            error.includes('symbolic'),
+                        ),
+                    ).toBe(true);
+                },
+                gitCleanupIntegrationTimeoutMs,
+            );
 
-        it(
-            'still marks a safe branch deleteable when an unrelated linked worktree HEAD reflog retains non-base history',
-            () => {
-                const fixture = createGitFixture();
-                const linkedWorktreePath = path.join(
-                    fixture.tempPath,
-                    'topic-worktree',
-                );
+            it(
+                'restores the original local branch name from the current archived tip',
+                () => {
+                    const fixture = createGitFixture();
+                    const archivedBranchName =
+                        'slop-refinery/archive/local/feature/manual-restore';
 
-                createMergedFeatureBranch(fixture.repoPath, 'feature');
-                createAttachedLinkedWorktreeWithDetachedHeadHistory(
-                    fixture,
-                    'topic',
-                    linkedWorktreePath,
-                );
+                    createMergedFeatureBranch(fixture.repoPath, 'feature');
+                    git(
+                        fixture.repoPath,
+                        ['branch', '-m', 'feature', archivedBranchName],
+                        false,
+                    );
 
-                const auditReport = runGitCleanupJson(fixture.repoPath, [
-                    'git-cleanup',
-                ]);
-                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
-
-                expect(
-                    safeDeleteBranch.state.repositoryReflogUniqueCommitCount,
-                ).toBeGreaterThan(0);
-                expect(
-                    safeDeleteBranch.state.repositoryLinkedWorktreePaths,
-                ).toContain(realpathSync(linkedWorktreePath));
-            },
-            gitCleanupIntegrationTimeoutMs,
-        );
-
-        it(
-            'still marks a safe branch deleteable when an unrelated dirty linked worktree path contains a newline',
-            () => {
-                const fixture = createGitFixture();
-                const cleanSiblingPath = path.join(
-                    fixture.tempPath,
-                    'newline-worktree',
-                );
-                const newlineWorktreePath = `${cleanSiblingPath}\nspoof`;
-
-                createMergedFeatureBranch(fixture.repoPath, 'feature');
-                git(fixture.repoPath, ['branch', 'clean-topic', 'main'], false);
-                git(fixture.repoPath, ['branch', 'dirty-topic', 'main'], false);
-                git(
-                    fixture.repoPath,
-                    ['worktree', 'add', cleanSiblingPath, 'clean-topic'],
-                    false,
-                );
-                git(
-                    fixture.repoPath,
-                    ['worktree', 'add', newlineWorktreePath, 'dirty-topic'],
-                    false,
-                );
-                writeFile(
-                    path.join(newlineWorktreePath, 'untracked.txt'),
-                    'dirty\n',
-                );
-
-                const auditReport = runGitCleanupJson(fixture.repoPath, [
-                    'git-cleanup',
-                ]);
-                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
-
-                expect(
-                    safeDeleteBranch.state.repositoryWorktreeDirtyPaths.some(
-                        (dirtyPath) => dirtyPath.includes('\nspoof'),
-                    ),
-                ).toBe(true);
-            },
-            gitCleanupIntegrationTimeoutMs,
-        );
-
-        it(
-            'still marks a safe branch deleteable when an unrelated worktree-private ref points outside main',
-            () => {
-                const fixture = createGitFixture();
-                const linkedWorktreePath = path.join(
-                    fixture.tempPath,
-                    'private-ref-worktree',
-                );
-
-                createMergedFeatureBranch(fixture.repoPath, 'feature');
-                git(fixture.repoPath, ['branch', 'topic', 'main'], false);
-                git(
-                    fixture.repoPath,
-                    ['worktree', 'add', linkedWorktreePath, 'topic'],
-                    false,
-                );
-                git(linkedWorktreePath, ['checkout', '--detach'], false);
-                commitFile(
-                    linkedWorktreePath,
-                    'private-ref.txt',
-                    'private-ref\n',
-                    'Create private ref work',
-                );
-                git(
-                    linkedWorktreePath,
-                    ['update-ref', 'refs/worktree/private-ref', 'HEAD'],
-                    false,
-                );
-                git(linkedWorktreePath, ['checkout', 'topic'], false);
-                rmSync(
-                    path.join(
-                        readAbsoluteGitDir(linkedWorktreePath),
-                        'logs',
-                        'HEAD',
-                    ),
-                    { force: true },
-                );
-
-                const auditReport = runGitCleanupJson(fixture.repoPath, [
-                    'git-cleanup',
-                ]);
-                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
-
-                expect(
-                    safeDeleteBranch.state.repositoryHiddenRefs.some((ref) =>
-                        ref.endsWith('/refs/worktree/private-ref'),
-                    ),
-                ).toBe(true);
-            },
-            gitCleanupIntegrationTimeoutMs,
-        );
-
-        it(
-            'still marks a safe branch deleteable when an unrelated worktree-private ref reflog retains history outside main',
-            () => {
-                const fixture = createGitFixture();
-                const linkedWorktreePath = path.join(
-                    fixture.tempPath,
-                    'private-reflog-worktree',
-                );
-
-                createMergedFeatureBranch(fixture.repoPath, 'feature');
-                git(fixture.repoPath, ['branch', 'topic', 'main'], false);
-                git(
-                    fixture.repoPath,
-                    ['worktree', 'add', linkedWorktreePath, 'topic'],
-                    false,
-                );
-                git(linkedWorktreePath, ['checkout', '--detach'], false);
-                commitFile(
-                    linkedWorktreePath,
-                    'private-reflog.txt',
-                    'private-reflog\n',
-                    'Create private reflog work',
-                );
-                git(
-                    linkedWorktreePath,
-                    [
-                        'update-ref',
-                        '--create-reflog',
-                        'refs/worktree/private-reflog',
-                        'HEAD',
-                    ],
-                    false,
-                );
-                git(
-                    linkedWorktreePath,
-                    ['update-ref', 'refs/worktree/private-reflog', 'topic'],
-                    false,
-                );
-                git(linkedWorktreePath, ['checkout', 'topic'], false);
-                rmSync(
-                    path.join(
-                        readAbsoluteGitDir(linkedWorktreePath),
-                        'logs',
-                        'HEAD',
-                    ),
-                    { force: true },
-                );
-
-                const auditReport = runGitCleanupJson(fixture.repoPath, [
-                    'git-cleanup',
-                ]);
-                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
-
-                expect(
-                    safeDeleteBranch.state.repositoryReflogUniqueCommitCount,
-                ).toBeGreaterThan(0);
-            },
-            gitCleanupIntegrationTimeoutMs,
-        );
-
-        it(
-            'still marks a safe branch deleteable when another live off-base branch has no reflog',
-            () => {
-                const fixture = createGitFixture();
-
-                createMergedFeatureBranch(fixture.repoPath, 'feature');
-                git(fixture.repoPath, ['checkout', '-b', 'topic'], false);
-                commitFile(
-                    fixture.repoPath,
-                    'topic.txt',
-                    'topic\n',
-                    'Create topic work',
-                );
-                git(fixture.repoPath, ['checkout', 'main'], false);
-                removeRefReflog(fixture.repoPath, 'refs', 'heads', 'topic');
-
-                const auditReport = runGitCleanupJson(fixture.repoPath, [
-                    'git-cleanup',
-                ]);
-                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
-
-                expect(safeDeleteBranch.state.repositoryHiddenRefs).toContain(
-                    'refs/heads/topic',
-                );
-            },
-            gitCleanupIntegrationTimeoutMs,
-        );
-
-        it(
-            'fails closed when archived local branch validation loses the preserving reflog',
-            () => {
-                const fixture = createGitFixture();
-                const archivedBranchName =
-                    'slop-refinery/archive/local/feature/manual-check';
-
-                createMergedFeatureBranch(fixture.repoPath, 'feature', {
-                    pushRemote: true,
-                });
-                git(
-                    fixture.repoPath,
-                    ['branch', '-m', 'feature', archivedBranchName],
-                    false,
-                );
-                removeRefReflog(
-                    fixture.repoPath,
-                    'refs',
-                    'heads',
-                    ...archivedBranchName.split('/'),
-                );
-
-                const archivedBranchValidation =
-                    validateArchivedBranchForTesting(
+                    const restoreResult = restoreArchivedBranchForTesting(
                         fixture.repoPath,
                         'feature',
                         archivedBranchName,
+                    );
+
+                    expect(restoreResult.restored).toBe(true);
+                    expect(restoreResult.errors).toEqual([]);
+                    expect(
+                        git(fixture.repoPath, ['branch', '--list', 'feature']),
+                    ).toContain('feature');
+                    expect(
+                        git(fixture.repoPath, [
+                            'branch',
+                            '--list',
+                            archivedBranchName,
+                        ]),
+                    ).toBe('');
+                },
+                gitCleanupIntegrationTimeoutMs,
+            );
+
+            it(
+                'restores the original local branch name from the current archived tip if the archive ref moved',
+                () => {
+                    const fixture = createGitFixture();
+                    const archivedBranchName =
+                        'slop-refinery/archive/local/feature/manual-restore-moved';
+
+                    createMergedFeatureBranch(fixture.repoPath, 'feature');
+                    createHiddenLocalRefNotOnBase(
+                        fixture.repoPath,
+                        'refs/original/local-restore-moved',
+                    );
+                    const movedArchiveSha = readCurrentSha(
+                        fixture.repoPath,
+                        'refs/original/local-restore-moved',
+                    );
+
+                    git(
+                        fixture.repoPath,
+                        ['branch', '-m', 'feature', archivedBranchName],
+                        false,
+                    );
+                    git(
+                        fixture.repoPath,
+                        ['branch', '-f', archivedBranchName, movedArchiveSha],
+                        false,
+                    );
+
+                    const restoreResult = restoreArchivedBranchForTesting(
+                        fixture.repoPath,
+                        'feature',
+                        archivedBranchName,
+                    );
+
+                    expect(restoreResult.restored).toBe(true);
+                    expect(restoreResult.errors).toEqual([]);
+                    expect(readCurrentSha(fixture.repoPath, 'feature')).toBe(
+                        movedArchiveSha,
+                    );
+                    expect(
+                        git(fixture.repoPath, [
+                            'branch',
+                            '--list',
+                            archivedBranchName,
+                        ]),
+                    ).toBe('');
+                },
+                gitCleanupIntegrationTimeoutMs,
+            );
+
+            it(
+                'restores a pinned branch at the expected SHA and preserves a moved archive ref',
+                () => {
+                    const fixture = createGitFixture();
+                    const archivedBranchName =
+                        'slop-refinery/archive/local/feature/manual-restore-pinned-moved';
+
+                    createMergedFeatureBranch(fixture.repoPath, 'feature');
+                    const originalBranchSha = readCurrentSha(
+                        fixture.repoPath,
+                        'feature',
+                    );
+                    createHiddenLocalRefNotOnBase(
+                        fixture.repoPath,
+                        'refs/original/local-restore-pinned-moved',
+                    );
+                    const movedArchiveSha = readCurrentSha(
+                        fixture.repoPath,
+                        'refs/original/local-restore-pinned-moved',
+                    );
+
+                    git(
+                        fixture.repoPath,
+                        ['branch', '-m', 'feature', archivedBranchName],
+                        false,
+                    );
+                    git(
+                        fixture.repoPath,
+                        ['branch', '-f', archivedBranchName, movedArchiveSha],
+                        false,
+                    );
+
+                    const restoreResult = restoreArchivedBranchForTesting(
+                        fixture.repoPath,
+                        'feature',
+                        archivedBranchName,
+                        originalBranchSha,
+                    );
+
+                    expect(restoreResult.restored).toBe(true);
+                    expect(restoreResult.preservedArchiveRef).toBe(true);
+                    expect(restoreResult.errors).toEqual([]);
+                    expect(readCurrentSha(fixture.repoPath, 'feature')).toBe(
+                        originalBranchSha,
+                    );
+                    expect(
                         readCurrentSha(fixture.repoPath, archivedBranchName),
-                    );
-
-                expect(archivedBranchValidation.archived).toBe(false);
-                expect(
-                    archivedBranchValidation.errors.some((error) =>
-                        error.includes('reflog'),
-                    ),
-                ).toBe(true);
-            },
-            gitCleanupIntegrationTimeoutMs,
-        );
-
-        it(
-            'fails closed when archived local branch validation sees a symbolic archive ref',
-            () => {
-                const fixture = createGitFixture();
-                const archivedBranchName =
-                    'slop-refinery/archive/local/feature/manual-symbolic-check';
-
-                createMergedFeatureBranch(fixture.repoPath, 'feature');
-                const expectedBranchSha = readCurrentSha(
-                    fixture.repoPath,
-                    'feature',
-                );
-                git(fixture.repoPath, ['branch', '-D', 'feature'], false);
-                git(
-                    fixture.repoPath,
-                    [
-                        'symbolic-ref',
-                        `refs/heads/${archivedBranchName}`,
-                        'refs/heads/main',
-                    ],
-                    false,
-                );
-
-                const archivedBranchValidation =
-                    validateArchivedBranchForTesting(
-                        fixture.repoPath,
-                        'feature',
-                        archivedBranchName,
-                        expectedBranchSha,
-                    );
-
-                expect(archivedBranchValidation.archived).toBe(false);
-                expect(
-                    archivedBranchValidation.errors.some((error) =>
-                        error.includes('symbolic'),
-                    ),
-                ).toBe(true);
-            },
-            gitCleanupIntegrationTimeoutMs,
-        );
-
-        it(
-            'fails closed when archived local branch validation sees a symbolic original ref',
-            () => {
-                const fixture = createGitFixture();
-                const archivedBranchName =
-                    'slop-refinery/archive/local/feature/manual-original-symbolic-check';
-
-                createMergedFeatureBranch(fixture.repoPath, 'feature');
-                const expectedBranchSha = readCurrentSha(
-                    fixture.repoPath,
-                    'feature',
-                );
-                git(
-                    fixture.repoPath,
-                    ['branch', '-m', 'feature', archivedBranchName],
-                    false,
-                );
-                git(
-                    fixture.repoPath,
-                    [
-                        'symbolic-ref',
-                        'refs/heads/feature',
-                        'refs/heads/missing-target',
-                    ],
-                    false,
-                );
-
-                const archivedBranchValidation =
-                    validateArchivedBranchForTesting(
-                        fixture.repoPath,
-                        'feature',
-                        archivedBranchName,
-                        expectedBranchSha,
-                    );
-
-                expect(archivedBranchValidation.archived).toBe(false);
-                expect(
-                    archivedBranchValidation.errors.some((error) =>
-                        error.includes('symbolic'),
-                    ),
-                ).toBe(true);
-            },
-            gitCleanupIntegrationTimeoutMs,
-        );
-
-        it(
-            'restores the original local branch name from the current archived tip',
-            () => {
-                const fixture = createGitFixture();
-                const archivedBranchName =
-                    'slop-refinery/archive/local/feature/manual-restore';
-
-                createMergedFeatureBranch(fixture.repoPath, 'feature');
-                git(
-                    fixture.repoPath,
-                    ['branch', '-m', 'feature', archivedBranchName],
-                    false,
-                );
-
-                const restoreResult = restoreArchivedBranchForTesting(
-                    fixture.repoPath,
-                    'feature',
-                    archivedBranchName,
-                );
-
-                expect(restoreResult.restored).toBe(true);
-                expect(restoreResult.errors).toEqual([]);
-                expect(
-                    git(fixture.repoPath, ['branch', '--list', 'feature']),
-                ).toContain('feature');
-                expect(
-                    git(fixture.repoPath, [
-                        'branch',
-                        '--list',
-                        archivedBranchName,
-                    ]),
-                ).toBe('');
-            },
-            gitCleanupIntegrationTimeoutMs,
-        );
-
-        it(
-            'restores the original local branch name from the current archived tip if the archive ref moved',
-            () => {
-                const fixture = createGitFixture();
-                const archivedBranchName =
-                    'slop-refinery/archive/local/feature/manual-restore-moved';
-
-                createMergedFeatureBranch(fixture.repoPath, 'feature');
-                createHiddenLocalRefNotOnBase(
-                    fixture.repoPath,
-                    'refs/original/local-restore-moved',
-                );
-                const movedArchiveSha = readCurrentSha(
-                    fixture.repoPath,
-                    'refs/original/local-restore-moved',
-                );
-
-                git(
-                    fixture.repoPath,
-                    ['branch', '-m', 'feature', archivedBranchName],
-                    false,
-                );
-                git(
-                    fixture.repoPath,
-                    ['branch', '-f', archivedBranchName, movedArchiveSha],
-                    false,
-                );
-
-                const restoreResult = restoreArchivedBranchForTesting(
-                    fixture.repoPath,
-                    'feature',
-                    archivedBranchName,
-                );
-
-                expect(restoreResult.restored).toBe(true);
-                expect(restoreResult.errors).toEqual([]);
-                expect(readCurrentSha(fixture.repoPath, 'feature')).toBe(
-                    movedArchiveSha,
-                );
-                expect(
-                    git(fixture.repoPath, [
-                        'branch',
-                        '--list',
-                        archivedBranchName,
-                    ]),
-                ).toBe('');
-            },
-            gitCleanupIntegrationTimeoutMs,
-        );
-
-        it(
-            'restores a pinned branch at the expected SHA and preserves a moved archive ref',
-            () => {
-                const fixture = createGitFixture();
-                const archivedBranchName =
-                    'slop-refinery/archive/local/feature/manual-restore-pinned-moved';
-
-                createMergedFeatureBranch(fixture.repoPath, 'feature');
-                const originalBranchSha = readCurrentSha(
-                    fixture.repoPath,
-                    'feature',
-                );
-                createHiddenLocalRefNotOnBase(
-                    fixture.repoPath,
-                    'refs/original/local-restore-pinned-moved',
-                );
-                const movedArchiveSha = readCurrentSha(
-                    fixture.repoPath,
-                    'refs/original/local-restore-pinned-moved',
-                );
-
-                git(
-                    fixture.repoPath,
-                    ['branch', '-m', 'feature', archivedBranchName],
-                    false,
-                );
-                git(
-                    fixture.repoPath,
-                    ['branch', '-f', archivedBranchName, movedArchiveSha],
-                    false,
-                );
-
-                const restoreResult = restoreArchivedBranchForTesting(
-                    fixture.repoPath,
-                    'feature',
-                    archivedBranchName,
-                    originalBranchSha,
-                );
-
-                expect(restoreResult.restored).toBe(true);
-                expect(restoreResult.preservedArchiveRef).toBe(true);
-                expect(restoreResult.errors).toEqual([]);
-                expect(readCurrentSha(fixture.repoPath, 'feature')).toBe(
-                    originalBranchSha,
-                );
-                expect(
-                    readCurrentSha(fixture.repoPath, archivedBranchName),
-                ).toBe(movedArchiveSha);
-            },
-            gitCleanupIntegrationTimeoutMs,
-        );
+                    ).toBe(movedArchiveSha);
+                },
+                gitCleanupIntegrationTimeoutMs,
+            );
+        });
     });
 
     describe('practical cleanup proof reductions', () => {
@@ -5033,6 +5190,41 @@ describe('git-cleanup CLI', () => {
                     pushRemote: true,
                 });
                 removeRefReflog(fixture.repoPath, 'refs', 'heads', 'feature');
+
+                const auditReport = runGitCleanupJson(fixture.repoPath, [
+                    'git-cleanup',
+                ]);
+                const safeDeleteBranch = expectSafeDeleteBranch(auditReport);
+
+                expect(safeDeleteBranch.state.branchReflogAvailable).toBe(true);
+                expect(
+                    safeDeleteBranch.state.branchReflogUniqueCommitCount,
+                ).toBe(0);
+                expect(safeDeleteBranch.reasonCodes).not.toContain(
+                    'branch_reflog_unavailable',
+                );
+            },
+            gitCleanupIntegrationTimeoutMs,
+        );
+
+        it(
+            'keeps a merged branch deleteable when its branch reflog is empty',
+            () => {
+                const fixture = createGitFixture();
+
+                createMergedFeatureBranch(fixture.repoPath, 'feature', {
+                    pushRemote: true,
+                });
+                writeFileSync(
+                    path.join(
+                        readGitCommonDir(fixture.repoPath),
+                        'logs',
+                        'refs',
+                        'heads',
+                        'feature',
+                    ),
+                    '',
+                );
 
                 const auditReport = runGitCleanupJson(fixture.repoPath, [
                     'git-cleanup',


### PR DESCRIPTION
## Summary
- Treat patch-equivalent local and origin branch tips as practical proof for git-cleanup deletion decisions.
- Keep branches under manual review when branch reflogs retain commits whose changes are not represented on main.
- Add audit and apply coverage for patch-equivalent hosted branches, plus branch reflog edge cases.
- Bump slop-refinery from 0.0.7 to 0.0.8 and refresh package-lock.json.

## Validation
- npm run format
- npm run lint
- npm run typecheck
- npx vitest run tests/git-cleanup.test.ts -t "applies cleanup to a hosted branch whose commits are patch-equivalent to main" --exclude "dist/**" --exclude "**/dist/**"
- npm test
- git diff --check
- Direct modeling repo dry run with modified CLI: 15 safe-delete, 10 needs-review, 1 protected, 0 skipped, 0 detached worktrees

## Notes
- The remaining manual-review branches in the modeling repo were still practical review cases: unmerged tips, checked-out or dirty linked worktrees, or reflog-only commits whose changes were not represented on main.