### PR TITLE
[codex] Enable auto-merge for ready author PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,7 @@ updates:
           day: monday
           time: '06:00'
           timezone: America/Denver
+      cooldown:
+          semver-patch-days: 3
+          semver-minor-days: 14
+          semver-major-days: 30

--- a/.github/workflows/author-auto-merge.yml
+++ b/.github/workflows/author-auto-merge.yml
@@ -1,0 +1,23 @@
+name: Author Auto Merge
+
+on:
+    pull_request_target:
+        types:
+            - ready_for_review
+
+permissions:
+    contents: write
+    pull-requests: write
+
+jobs:
+    enable-auto-merge:
+        if: github.event.pull_request.user.login == 'lastmjs'
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+
+        steps:
+            - name: Enable auto-merge
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  PR_URL: ${{ github.event.pull_request.html_url }}
+              run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Summary
- Add a minimal ready-for-review workflow for PR auto-merge.
- Scope the workflow to PRs authored by `lastmjs`.
- Use GitHub auto-merge with squash so required checks and branch rules still gate the merge.

## Validation
- `npm run format`
- `npm run lint`
- `npm run typecheck`