### PR TITLE
[codex] Align Node types with Node 24

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,7 @@ updates:
           semver-patch-days: 3
           semver-minor-days: 14
           semver-major-days: 30
+      ignore:
+          - dependency-name: '@types/node'
+            update-types:
+                - 'version-update:semver-major'

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
                 "slop-refinery": "dist/src/cli/bin.js"
             },
             "devDependencies": {
-                "@types/node": "^25.6.0",
+                "@types/node": "^24.0.0",
                 "eslint": "^10.2.1",
                 "eslint-import-resolver-typescript": "^4.4.4",
                 "jiti": "^2.6.1",
@@ -29,6 +29,9 @@
                 "tsx": "^4.21.0",
                 "typescript": "^6.0.3",
                 "vitest": "^4.1.5"
+            },
+            "engines": {
+                "node": "24"
             }
         },
         "node_modules/@emnapi/core": {
@@ -1031,13 +1034,13 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "25.9.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-            "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+            "version": "24.12.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+            "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "undici-types": ">=7.24.0 <7.24.7"
+                "undici-types": "~7.16.0"
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3426,9 +3429,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "7.24.6",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-            "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+            "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
             "dev": true,
             "license": "MIT"
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
                 "slop-refinery": "dist/src/cli/bin.js"
             },
             "devDependencies": {
-                "@types/node": "^24.0.0",
+                "@types/node": "^24",
                 "eslint": "^10.2.1",
                 "eslint-import-resolver-typescript": "^4.4.4",
                 "jiti": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
         "type": "git",
         "url": "git+https://github.com/HOWMZofficial/slop-refinery.git"
     },
+    "engines": {
+        "node": "24"
+    },
     "exports": {
         ".": {
             "types": "./dist/src/lib/index.d.ts",
@@ -46,7 +49,7 @@
         "typescript-eslint": "^8.59.1"
     },
     "devDependencies": {
-        "@types/node": "^25.6.0",
+        "@types/node": "^24.0.0",
         "eslint": "^10.2.1",
         "eslint-import-resolver-typescript": "^4.4.4",
         "jiti": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "typescript-eslint": "^8.59.1"
     },
     "devDependencies": {
-        "@types/node": "^24.0.0",
+        "@types/node": "^24",
         "eslint": "^10.2.1",
         "eslint-import-resolver-typescript": "^4.4.4",
         "jiti": "^2.6.1",


### PR DESCRIPTION
## Summary

- pin `@types/node` to the Node 24 type line
- add an explicit Node 24 engine declaration
- refresh `package-lock.json` so Node types resolve to `24.12.4` and matching `undici-types`

## Why

CI and publish jobs run on Node 24, but TypeScript was checking against Node 25 type declarations. This could allow code to typecheck while using APIs that do not exist in the runtime.

## Validation

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `git diff --check`

Full `npm test` was started but stopped after an extended git-fixture run; CI will run the complete suite on the PR.