### PR TITLE
[codex] Add Node version alignment ESLint rule

### DIFF
--- a/eslint/config.ts
+++ b/eslint/config.ts
@@ -1,4 +1,13 @@
 import { recommendedConfig } from '../src/eslint-plugin/index.ts';
+import { slopRefinery } from '../src/eslint-plugin/plugin.ts';
+import textEslintParser from '../src/eslint-plugin/text-eslint-parser.ts';
+
+const NODE_VERSION_ALIGNMENT_FILES = [
+    'package.json',
+    '.github/dependabot.yml',
+    '.github/workflows/*.yml',
+    '.github/workflows/*.yaml',
+];
 
 const config = [
     {
@@ -8,6 +17,18 @@ const config = [
         ],
     },
     ...recommendedConfig,
+    {
+        files: NODE_VERSION_ALIGNMENT_FILES,
+        languageOptions: {
+            parser: textEslintParser,
+        },
+        plugins: {
+            'slop-refinery': slopRefinery,
+        },
+        rules: {
+            'slop-refinery/node-version-alignment': 'error',
+        },
+    },
     {
         files: [
             'eslint/**/*.ts',

--- a/src/eslint-plugin/plugin.ts
+++ b/src/eslint-plugin/plugin.ts
@@ -3,12 +3,14 @@ import type { Rule } from 'eslint';
 import { functionOrderRule } from './rules/function-order.ts';
 import { initAtBottomRule } from './rules/init-at-bottom.ts';
 import { noDefaultExportRule } from './rules/no-default-export.ts';
+import { nodeVersionAlignmentRule } from './rules/node-version-alignment.ts';
 import { typesAtTopRule } from './rules/types-at-top.ts';
 
 const rules: Record<string, Rule.RuleModule> = {
     'function-order': functionOrderRule,
     'init-at-bottom': initAtBottomRule,
     'no-default-export': noDefaultExportRule,
+    'node-version-alignment': nodeVersionAlignmentRule,
     'types-at-top': typesAtTopRule,
 };
 

--- a/src/eslint-plugin/rules/node-version-alignment.ts
+++ b/src/eslint-plugin/rules/node-version-alignment.ts
@@ -1,0 +1,425 @@
+import type { Rule } from 'eslint';
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+type AnyNode = any;
+type ConfigFileKind = 'dependabot' | 'packageJson' | 'untracked' | 'workflow';
+type IndexedLine = {
+    index: number;
+    text: string;
+};
+type NodeEngine = {
+    major: string;
+};
+type NodeEngineResult =
+    | {
+          engine: NodeEngine;
+          problem?: never;
+      }
+    | {
+          engine?: never;
+          problem: {
+              actual?: string;
+              messageId: 'invalidNodeEngine' | 'missingNodeEngine';
+          };
+      };
+type PackageJson = {
+    dependencies?: unknown;
+    devDependencies?: unknown;
+    engines?: unknown;
+};
+type ReportData = Record<string, string>;
+type RuleContext = any;
+type TextBlock = {
+    start: number;
+    text: string;
+};
+
+const DEPENDABOT_PATH = '.github/dependabot.yml';
+const NODE_ENGINE_PATTERN = /^\d+$/u;
+const NODE_TYPES_PACKAGE_NAME = '@types/node';
+const NODE_VERSION_LINE_PATTERN = /^(\s*node-version:\s*)([^#]+)/u;
+const WORKFLOW_PATH_PATTERN = /^\.github\/workflows\/.+\.ya?ml$/u;
+
+export const nodeVersionAlignmentRule: Rule.RuleModule = {
+    create(context: RuleContext) {
+        return {
+            Program(node: AnyNode) {
+                checkNodeVersionAlignment(context, node);
+            },
+        };
+    },
+    meta: {
+        docs: {
+            description:
+                'Keep Node-related package, workflow, and Dependabot versions aligned to package.json engines.node.',
+        },
+        messages: {
+            invalidNodeEngine:
+                'package.json engines.node must be a single major version like "24"; found "{{actual}}".',
+            invalidPackageJson:
+                'package.json must be valid JSON so Node version alignment can be checked.',
+            mismatchedNodeTypes:
+                'package.json devDependencies["@types/node"] must be "{{expected}}" because engines.node is "{{engine}}"; found "{{actual}}".',
+            mismatchedWorkflowNodeVersion:
+                'GitHub workflow node-version must be "{{expected}}" because package.json engines.node is "{{engine}}"; found "{{actual}}".',
+            missingDependabotNodeTypesMajorIgnore:
+                'Dependabot npm updates must ignore semver-major updates for @types/node so Node types stay aligned with engines.node "{{engine}}".',
+            missingNodeEngine:
+                'package.json must define engines.node as a single major version like "24".',
+        },
+        schema: [],
+        type: 'problem',
+    },
+};
+
+function checkNodeVersionAlignment(context: RuleContext, node: AnyNode): void {
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
+    const sourceText = sourceCode.text;
+    const relativeFilePath = getRelativeFilePath(context.filename);
+    const configFileKind = getConfigFileKind(relativeFilePath);
+
+    if (configFileKind === 'packageJson') {
+        checkPackageJson(context, node, sourceText);
+        return;
+    }
+
+    const rootEngine = readRootNodeEngine();
+
+    if (rootEngine === undefined) {
+        return;
+    }
+
+    if (configFileKind === 'workflow') {
+        checkWorkflowNodeVersions(context, node, sourceText, rootEngine);
+        return;
+    }
+
+    if (configFileKind === 'dependabot') {
+        checkDependabotNodeTypesIgnore(context, node, sourceText, rootEngine);
+    }
+}
+
+function checkPackageJson(
+    context: RuleContext,
+    node: AnyNode,
+    sourceText: string,
+): void {
+    const packageJson = parsePackageJson(sourceText);
+
+    if (packageJson === undefined) {
+        reportAtIndex(context, node, 0, 'invalidPackageJson');
+        return;
+    }
+
+    const engineResult = readNodeEngine(packageJson);
+
+    if (engineResult.problem !== undefined) {
+        reportAtIndex(context, node, 0, engineResult.problem.messageId, {
+            actual: engineResult.problem.actual ?? 'missing',
+        });
+        return;
+    }
+
+    const expected = getExpectedNodeTypesRange(engineResult.engine);
+    const actual = getNodeTypesVersion(packageJson);
+
+    if (actual !== expected) {
+        reportAtIndex(context, node, 0, 'mismatchedNodeTypes', {
+            actual: formatActualValue(actual),
+            engine: engineResult.engine.major,
+            expected,
+        });
+    }
+}
+
+function checkWorkflowNodeVersions(
+    context: RuleContext,
+    node: AnyNode,
+    sourceText: string,
+    rootEngine: NodeEngine,
+): void {
+    for (const line of getIndexedLines(sourceText)) {
+        const nodeVersion = parseWorkflowNodeVersion(line);
+
+        if (nodeVersion === undefined) {
+            continue;
+        }
+
+        if (nodeVersion.version !== rootEngine.major) {
+            reportAtIndex(
+                context,
+                node,
+                nodeVersion.index,
+                'mismatchedWorkflowNodeVersion',
+                {
+                    actual: nodeVersion.version,
+                    engine: rootEngine.major,
+                    expected: rootEngine.major,
+                },
+            );
+        }
+    }
+}
+
+function checkDependabotNodeTypesIgnore(
+    context: RuleContext,
+    node: AnyNode,
+    sourceText: string,
+    rootEngine: NodeEngine,
+): void {
+    const npmUpdateBlock = getDependabotNpmUpdateBlock(sourceText);
+
+    if (
+        npmUpdateBlock === undefined ||
+        !hasNodeTypesMajorIgnore(npmUpdateBlock.text)
+    ) {
+        reportAtIndex(
+            context,
+            node,
+            npmUpdateBlock?.start ?? 0,
+            'missingDependabotNodeTypesMajorIgnore',
+            {
+                engine: rootEngine.major,
+            },
+        );
+    }
+}
+
+function getRelativeFilePath(filename: string): string {
+    return path.relative(process.cwd(), filename).split(path.sep).join('/');
+}
+
+function getConfigFileKind(relativeFilePath: string): ConfigFileKind {
+    if (relativeFilePath === 'package.json') {
+        return 'packageJson';
+    }
+
+    if (relativeFilePath === DEPENDABOT_PATH) {
+        return 'dependabot';
+    }
+
+    if (WORKFLOW_PATH_PATTERN.test(relativeFilePath)) {
+        return 'workflow';
+    }
+
+    return 'untracked';
+}
+
+function readRootNodeEngine(): NodeEngine | undefined {
+    const packageJsonPath = path.join(process.cwd(), 'package.json');
+
+    try {
+        const packageJson = parsePackageJson(
+            fs.readFileSync(packageJsonPath, 'utf8'),
+        );
+
+        return packageJson === undefined
+            ? undefined
+            : readNodeEngine(packageJson).engine;
+    } catch {
+        return undefined;
+    }
+}
+
+function parsePackageJson(sourceText: string): PackageJson | undefined {
+    try {
+        const parsedJson: unknown = JSON.parse(sourceText);
+
+        return isRecord(parsedJson) ? parsedJson : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+function readNodeEngine(packageJson: PackageJson): NodeEngineResult {
+    const engines = packageJson.engines;
+
+    if (!isRecord(engines) || engines.node === undefined) {
+        return {
+            problem: {
+                messageId: 'missingNodeEngine',
+            },
+        };
+    }
+
+    if (
+        typeof engines.node !== 'string' ||
+        !NODE_ENGINE_PATTERN.test(engines.node)
+    ) {
+        return {
+            problem: {
+                actual: formatActualValue(engines.node),
+                messageId: 'invalidNodeEngine',
+            },
+        };
+    }
+
+    return {
+        engine: {
+            major: engines.node,
+        },
+    };
+}
+
+function getExpectedNodeTypesRange(nodeEngine: NodeEngine): string {
+    return `^${nodeEngine.major}`;
+}
+
+function getNodeTypesVersion(packageJson: PackageJson): unknown {
+    return isRecord(packageJson.devDependencies)
+        ? packageJson.devDependencies[NODE_TYPES_PACKAGE_NAME]
+        : undefined;
+}
+
+function getIndexedLines(sourceText: string): IndexedLine[] {
+    const lines = sourceText.split('\n');
+
+    return lines.map((text, lineNumber) => {
+        return {
+            index: getLineStartIndex(lines, lineNumber),
+            text,
+        };
+    });
+}
+
+function getLineStartIndex(lines: string[], lineNumber: number): number {
+    return lines.slice(0, lineNumber).reduce((index, line) => {
+        return index + line.length + 1;
+    }, 0);
+}
+
+function parseWorkflowNodeVersion(
+    line: IndexedLine,
+): { index: number; version: string } | undefined {
+    const match = NODE_VERSION_LINE_PATTERN.exec(line.text);
+
+    if (match === null) {
+        return undefined;
+    }
+
+    return {
+        index: line.index + match[1].length,
+        version: normalizeYamlScalar(match[2]),
+    };
+}
+
+function getDependabotNpmUpdateBlock(
+    sourceText: string,
+): TextBlock | undefined {
+    const lines = getIndexedLines(sourceText);
+
+    for (const [lineNumber, line] of lines.entries()) {
+        const ecosystemIndent = getPackageEcosystemIndent(line.text, 'npm');
+
+        if (ecosystemIndent === undefined) {
+            continue;
+        }
+
+        const blockEnd = findNextPackageEcosystemIndex(
+            lines,
+            lineNumber + 1,
+            ecosystemIndent,
+            sourceText.length,
+        );
+
+        return {
+            start: line.index,
+            text: sourceText.slice(line.index, blockEnd),
+        };
+    }
+
+    return undefined;
+}
+
+function getPackageEcosystemIndent(
+    line: string,
+    ecosystem: string,
+): string | undefined {
+    const pattern = new RegExp(
+        `^(\\s*)-\\s*package-ecosystem:\\s*['"]?${escapeRegExp(ecosystem)}['"]?\\s*$`,
+        'u',
+    );
+    const match = pattern.exec(line);
+
+    return match?.[1];
+}
+
+function findNextPackageEcosystemIndex(
+    lines: IndexedLine[],
+    startLineNumber: number,
+    ecosystemIndent: string,
+    fallbackIndex: number,
+): number {
+    for (const line of lines.slice(startLineNumber)) {
+        if (line.text.startsWith(`${ecosystemIndent}- package-ecosystem:`)) {
+            return line.index;
+        }
+    }
+
+    return fallbackIndex;
+}
+
+function hasNodeTypesMajorIgnore(blockText: string): boolean {
+    return (
+        /^\s*ignore:\s*$/mu.test(blockText) &&
+        /dependency-name:\s*['"]?@types\/node['"]?/u.test(blockText) &&
+        /['"]?version-update:semver-major['"]?/u.test(blockText)
+    );
+}
+
+function normalizeYamlScalar(rawValue: string): string {
+    const trimmedValue = rawValue.trim();
+
+    if (
+        (trimmedValue.startsWith("'") && trimmedValue.endsWith("'")) ||
+        (trimmedValue.startsWith('"') && trimmedValue.endsWith('"'))
+    ) {
+        return trimmedValue.slice(1, -1).trim();
+    }
+
+    return trimmedValue;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function formatActualValue(value: unknown): string {
+    if (value === undefined) {
+        return 'missing';
+    }
+
+    if (typeof value === 'string') {
+        return value;
+    }
+
+    return JSON.stringify(value) ?? String(value);
+}
+
+function escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`);
+}
+
+function reportAtIndex(
+    context: RuleContext,
+    node: AnyNode,
+    index: number,
+    messageId: string,
+    data?: ReportData,
+): void {
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
+    const start = sourceCode.getLocFromIndex(index);
+    const end = sourceCode.getLocFromIndex(index + 1);
+
+    context.report({
+        data,
+        loc: {
+            end,
+            start,
+        },
+        messageId,
+        node,
+    });
+}

--- a/src/eslint-plugin/text-eslint-parser.ts
+++ b/src/eslint-plugin/text-eslint-parser.ts
@@ -1,0 +1,55 @@
+type Position = {
+    column: number;
+    line: number;
+};
+
+type ProgramNode = {
+    body: [];
+    comments: [];
+    loc: {
+        end: Position;
+        start: Position;
+    };
+    range: [number, number];
+    sourceType: 'script';
+    tokens: [];
+    type: 'Program';
+};
+
+const textEslintParser = {
+    parseForESLint(sourceText: string): { ast: ProgramNode } {
+        return {
+            ast: createEmptyProgram(sourceText),
+        };
+    },
+};
+
+export default textEslintParser;
+
+function createEmptyProgram(sourceText: string): ProgramNode {
+    return {
+        body: [],
+        comments: [],
+        loc: {
+            end: getLocFromIndex(sourceText, sourceText.length),
+            start: {
+                column: 0,
+                line: 1,
+            },
+        },
+        range: [0, sourceText.length],
+        sourceType: 'script',
+        tokens: [],
+        type: 'Program',
+    };
+}
+
+function getLocFromIndex(sourceText: string, index: number): Position {
+    const linesBeforeIndex = sourceText.slice(0, index).split('\n');
+    const lastLineBeforeIndex = linesBeforeIndex.at(-1) ?? '';
+
+    return {
+        column: lastLineBeforeIndex.length,
+        line: linesBeforeIndex.length,
+    };
+}

--- a/tests/node-version-alignment.test.ts
+++ b/tests/node-version-alignment.test.ts
@@ -1,0 +1,253 @@
+import { nodeVersionAlignmentRule } from '../src/eslint-plugin/rules/node-version-alignment.ts';
+import textEslintParser from '../src/eslint-plugin/text-eslint-parser.ts';
+import { createTextRuleTester, repoPath } from './test-harness.ts';
+
+type InvalidCase = {
+    code: string;
+    errors: Array<{ messageId: string }>;
+    filename: string;
+};
+
+type ValidCase = {
+    code: string;
+    filename: string;
+};
+
+const dependabotPath = repoPath('.github', 'dependabot.yml');
+const packageJsonPath = repoPath('package.json');
+const ruleTester = createTextRuleTester(textEslintParser);
+const workflowPath = repoPath(
+    '.github',
+    'workflows',
+    'pull-request-checks.yml',
+);
+const invalidCases: InvalidCase[] = [
+    {
+        code: '{',
+        errors: [{ messageId: 'invalidPackageJson' }],
+        filename: packageJsonPath,
+    },
+    invalidPackageCase(
+        {
+            devDependencies: {
+                '@types/node': '^24',
+            },
+        },
+        'missingNodeEngine',
+    ),
+    invalidPackageCase(
+        {
+            devDependencies: {
+                '@types/node': '^24',
+            },
+            engines: {
+                node: 24,
+            },
+        },
+        'invalidNodeEngine',
+    ),
+    invalidPackageCase(
+        {
+            devDependencies: {
+                '@types/node': '^24',
+            },
+            engines: {
+                node: '^24',
+            },
+        },
+        'invalidNodeEngine',
+    ),
+    invalidPackageCase(
+        {
+            devDependencies: {},
+            engines: {
+                node: '24',
+            },
+        },
+        'mismatchedNodeTypes',
+    ),
+    invalidPackageCase(
+        {
+            devDependencies: {
+                '@types/node': '^24.0.0',
+            },
+            engines: {
+                node: '24',
+            },
+        },
+        'mismatchedNodeTypes',
+    ),
+    invalidPackageCase(
+        {
+            devDependencies: {
+                '@types/node': '^25',
+            },
+            engines: {
+                node: '24',
+            },
+        },
+        'mismatchedNodeTypes',
+    ),
+    invalidWorkflowCase("node-version: '25'"),
+    invalidWorkflowCase("node-version: '24.0.0'"),
+    {
+        code: `
+version: 2
+
+updates:
+    - package-ecosystem: npm
+      directory: /
+      schedule:
+          interval: weekly
+`,
+        errors: [{ messageId: 'missingDependabotNodeTypesMajorIgnore' }],
+        filename: dependabotPath,
+    },
+];
+const validCases: ValidCase[] = [
+    validPackageCase({
+        devDependencies: {
+            '@types/node': '^24',
+        },
+        engines: {
+            node: '24',
+        },
+    }),
+    validPackageCase({
+        dependencies: {
+            eslint: '^10.0.0',
+        },
+        devDependencies: {
+            '@types/node': '^24',
+            typescript: '^6.0.0',
+        },
+        engines: {
+            node: '24',
+        },
+    }),
+    validPackageCase({
+        devDependencies: {
+            '@types/node': '^24',
+        },
+        engines: {
+            node: '24',
+        },
+        scripts: {
+            lint: 'eslint .',
+        },
+    }),
+    validWorkflowCase("node-version: '24'"),
+    validWorkflowCase('node-version: 24'),
+    {
+        code: `
+name: Pull Request Checks
+
+jobs:
+    checks:
+        steps:
+            - run: npm ci
+`,
+        filename: workflowPath,
+    },
+    validWorkflowCase('node-version: 24 # Keep this aligned to package.json.'),
+    {
+        code: `
+version: 2
+
+updates:
+    - package-ecosystem: npm
+      directory: /
+      ignore:
+          - dependency-name: '@types/node'
+            update-types:
+                - 'version-update:semver-major'
+`,
+        filename: dependabotPath,
+    },
+    {
+        code: `
+version: 2
+
+updates:
+    - package-ecosystem: "npm"
+      directory: /
+      ignore:
+          - dependency-name: "@types/node"
+            update-types:
+                - "version-update:semver-major"
+`,
+        filename: dependabotPath,
+    },
+    {
+        code: `
+version: 2
+
+updates:
+    - package-ecosystem: github-actions
+      directory: /
+
+    - package-ecosystem: npm
+      directory: /
+      ignore:
+          - dependency-name: '@types/node'
+            update-types:
+                - 'version-update:semver-major'
+`,
+        filename: dependabotPath,
+    },
+];
+
+function invalidPackageCase(
+    packageJson: Record<string, unknown>,
+    messageId: string,
+): InvalidCase {
+    return {
+        code: formatPackageJson(packageJson),
+        errors: [{ messageId }],
+        filename: packageJsonPath,
+    };
+}
+
+function invalidWorkflowCase(nodeVersionLine: string): InvalidCase {
+    return {
+        code: formatWorkflow(nodeVersionLine),
+        errors: [{ messageId: 'mismatchedWorkflowNodeVersion' }],
+        filename: workflowPath,
+    };
+}
+
+function validPackageCase(packageJson: Record<string, unknown>): ValidCase {
+    return {
+        code: formatPackageJson(packageJson),
+        filename: packageJsonPath,
+    };
+}
+
+function validWorkflowCase(nodeVersionLine: string): ValidCase {
+    return {
+        code: formatWorkflow(nodeVersionLine),
+        filename: workflowPath,
+    };
+}
+
+function formatPackageJson(packageJson: Record<string, unknown>): string {
+    return JSON.stringify(packageJson, null, 4);
+}
+
+function formatWorkflow(nodeVersionLine: string): string {
+    return `
+name: Pull Request Checks
+
+jobs:
+    checks:
+        steps:
+            - uses: actions/setup-node@v6
+              with:
+                  ${nodeVersionLine}
+`;
+}
+
+ruleTester.run('node-version-alignment', nodeVersionAlignmentRule, {
+    invalid: invalidCases,
+    valid: validCases,
+});

--- a/tests/test-harness.ts
+++ b/tests/test-harness.ts
@@ -31,6 +31,14 @@ export function createTypeScriptRuleTester(): any {
     });
 }
 
+export function createTextRuleTester(parser: any): any {
+    return new RuleTester({
+        languageOptions: {
+            parser,
+        },
+    });
+}
+
 export function repoPath(...segments: string[]): string {
     return path.join(process.cwd(), ...segments);
 }


### PR DESCRIPTION
## Summary

- adds slop-refinery/node-version-alignment to keep Node metadata derived from package.json engines.node
- applies the rule to package.json, Dependabot config, and GitHub workflow YAML files
- adds text parser support and RuleTester coverage for package, workflow, and Dependabot cases

## Validation

- npm run format
- npm run lint
- npm run typecheck
- npx vitest run tests/node-version-alignment.test.ts
- git diff --check

Note: full npm test was started, but the long git-cleanup fixture suite did not complete within the interactive turn and was stopped after several minutes without a failure signal.