### PR TITLE
Bump version to 0.0.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "slop-refinery",
-    "version": "0.0.9",
+    "version": "0.0.10",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "slop-refinery",
-            "version": "0.0.9",
+            "version": "0.0.10",
             "license": "MIT",
             "dependencies": {
                 "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "slop-refinery",
-    "version": "0.0.9",
+    "version": "0.0.10",
     "description": "Refines AI slop into clean code: correct, simple, maintainable",
     "type": "module",
     "license": "MIT",


### PR DESCRIPTION
## Summary

- bump the package version from `0.0.9` to `0.0.10`
- keep the root package metadata in `package-lock.json` synchronized

## Why

Prepare the next Slop Refinery package release containing the updated skills already present on `main`.

## Impact

The package will report version `0.0.10`; no runtime behavior or dependencies change.

## Validation

- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `slop-refinery-irreducible-simplicity` review